### PR TITLE
Sftp cleanup and bugfixes

### DIFF
--- a/sftp-common.c
+++ b/sftp-common.c
@@ -283,17 +283,6 @@ ls_file(const char *name, const struct stat *st, int remote, int si_units)
 #include <windows.h>
 
 void
-strmode_from_attrib(unsigned attrib, char *p)
-{
-	if (attrib & FILE_ATTRIBUTE_REPARSE_POINT)
-		*p = 'l';
-	else if (attrib & FILE_ATTRIBUTE_DIRECTORY)
-		*p = 'd';
-	else
-		*p = '-';
-}
-
-void
 strmode(mode_t mode, char *p)
 {
 	/* print type */

--- a/sftp-common.c
+++ b/sftp-common.c
@@ -226,16 +226,16 @@ ls_file(const char *name, const struct stat *st, int remote, int si_units)
 	time_t now;
 
     strmode(st->st_mode, mode);
-#ifdef WINDOWS
-	strmode_from_attrib(remote, mode);
-#endif
+
 	if (!remote) {
 #ifndef WIN32_FIXME
         user = user_from_uid(st->st_uid, 0);
 #else
-        user = "\0";
-        snprintf(gbuf, sizeof gbuf, "%u", (u_int)st->st_gid);
-        group = gbuf;
+		snprintf(ubuf, sizeof ubuf, "%u", (u_int)st->st_uid);
+		user = ubuf;
+
+		snprintf(gbuf, sizeof gbuf, "%u", (u_int)st->st_gid);
+		group = gbuf;
 #endif
 	} else {
 		snprintf(ubuf, sizeof ubuf, "%u", (u_int)st->st_uid);

--- a/sftp.c
+++ b/sftp.c
@@ -651,8 +651,7 @@ process_get(struct sftp_conn *conn, const char *src, const char *dst,
 			} else {
 				abs_dst = xstrdup(dst);
 			}
-		} else if (dst) {
-			//BALU (this can be removed after glob is implemented).
+		} else if (dst) {			
 #ifdef WINDOWS
 			{
 				if (is_dir(dst)) {
@@ -750,8 +749,7 @@ process_put(struct sftp_conn *conn, const char *src, const char *dst,
 	}
 
 	/* If we aren't fetching to pwd then stash this status for later */
-	if (tmp_dst != NULL) {
-		// BALU - To get the real path.
+	if (tmp_dst != NULL) {		
 		#ifdef WINDOWS
 			if (strlen(tmp_dst) >= 2 && tmp_dst[2] == ':')
 				tmp_dst = do_realpath(conn, tmp_dst);
@@ -790,8 +788,7 @@ process_put(struct sftp_conn *conn, const char *src, const char *dst,
 				abs_dst = path_append(tmp_dst, filename);
 			else
 				abs_dst = xstrdup(tmp_dst);
-		} else if (tmp_dst) {
-			//BALU (this can be removed after glob is implemented).
+		} else if (tmp_dst) {			
 			#ifdef WINDOWS
 			{
 				if (dst_is_dir)
@@ -2455,10 +2452,8 @@ connect_to_server(char *path, char **args, int *in, int *out)
 		/*
 		* Create child ssh process with given stdout/stdin.
 		*/
-		debug("Executing ssh client: \"%.500s\"...\n", fullCmd);
-		
-		//BALU
-		memcpy(fullCmd, "sftp-server.exe", 16);		
+		debug("Executing ssh client: \"%.500s\"...\n", fullCmd);	
+
 		if (CreateProcessW(NULL, utf8_to_utf16(fullCmd), NULL, NULL, TRUE,
 			NORMAL_PRIORITY_CLASS, NULL,
 			NULL, &si, &pi) == TRUE) {

--- a/sftp.c
+++ b/sftp.c
@@ -608,8 +608,12 @@ process_get(struct sftp_conn *conn, const char *src, const char *dst,
 	abs_src = make_absolute(abs_src, pwd);
 
 #ifdef WINDOWS
-	if(strlen(abs_src) >= 2 && abs_src[2] == ':')
-		abs_src = do_realpath(conn, abs_src);
+	if (strlen(abs_src) >= 2 && abs_src[2] == ':')
+	{
+		char *realPath = do_realpath(conn, abs_src);
+		free(abs_src);
+		abs_src = realPath;
+	}
 #endif	
 
 	memset(&g, 0, sizeof(g));
@@ -751,8 +755,12 @@ process_put(struct sftp_conn *conn, const char *src, const char *dst,
 	/* If we aren't fetching to pwd then stash this status for later */
 	if (tmp_dst != NULL) {		
 		#ifdef WINDOWS
-			if (strlen(tmp_dst) >= 2 && tmp_dst[2] == ':')
-				tmp_dst = do_realpath(conn, tmp_dst);
+		if (strlen(tmp_dst) >= 2 && tmp_dst[2] == ':')
+		{
+			char *realPath = do_realpath(conn, tmp_dst);
+			free(tmp_dst);
+			tmp_dst = realPath;
+		}
 		#endif
 
 		dst_is_dir = remote_is_dir(conn, tmp_dst);


### PR DESCRIPTION
1.	rm pattern (ex - rm 1*) makes the sftp client to crash.
Fix - The SFTP client is crashing because the windows implementation of glob() doesn't populate the paths[]. The existing code assumes paths[] is always populated but in-fact in windows it's not so it crashes. I have added a check to ensure paths[] is properly set before accessing it.
2.	ls -l command, doesn't set the directory flag for directories.
Fix - strmode_from_attrib() is removed. This method is overriding the directory flag set by strmode().
3.	ls -l command, is not showing the userid.
Fix - user is set to '\0' so empty character is getting printed. Now changed this to print the userId. Although userId, groupId will always be 0 incase of windows, but this will be fixed later to print the correct username, groupname associated with the file.
4.	put,get commands doesn't take the full windows path (either directory+file path or just directory).
Fix - When the full path is given then we fail to derive the actual windows path. Now we fetch the windows path by calling the do_realpath().
