### PR TITLE
win32: Fix execute SSHD child process with any module name

### DIFF
--- a/contrib/win32/win32compat/inc/unistd.h
+++ b/contrib/win32/win32compat/inc/unistd.h
@@ -81,5 +81,5 @@ char *crypt(const char *key, const char *salt);
 int link(const char *oldpath, const char *newpath);
 int readlink(const char *path, char *link, int linklen);
 
-int spawn_child_vp(char * path, char ** argv, int in, int out, int err, DWORD flags);
+int spawn_child_vp(char * path, char ** argv, int in, int out, int err, unsigned long flags);
 int spawn_child(char* cmd, int in, int out, int err, unsigned long flags);

--- a/contrib/win32/win32compat/inc/unistd.h
+++ b/contrib/win32/win32compat/inc/unistd.h
@@ -81,4 +81,5 @@ char *crypt(const char *key, const char *salt);
 int link(const char *oldpath, const char *newpath);
 int readlink(const char *path, char *link, int linklen);
 
+int spawn_child_vp(char * path, char ** argv, int in, int out, int err, DWORD flags);
 int spawn_child(char* cmd, int in, int out, int err, unsigned long flags);

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -1,5 +1,12 @@
 #define PATH_MAX MAX_PATH
 
+#define GOTO_CLEANUP_IF(_cond_,_err_) do {  \
+    if ((_cond_)) {                         \
+        hr = _err_;                         \
+        goto cleanup;                       \
+    }                                       \
+} while(0)
+
 /* removes first '/' for Windows paths that are unix styled. Ex: /c:/ab.cd */
 char * sanitized_path(const char *);
 

--- a/sshd.c
+++ b/sshd.c
@@ -1311,6 +1311,7 @@ server_accept_loop(int *sock_in, int *sock_out, int *newsock, int *config_s)
 					close(*newsock);
 					/* close child end of startup pipe. parent end will automatically be cleaned up on next iteration*/
 					close(startup_p[1]);
+					free(path_utf8);
 					continue;
 				}
                 


### PR DESCRIPTION
If sshd module named as "sshd v74.exe", then child process can not started!

Proof: https://github.com/PowerShell/Win32-OpenSSH/issues/504