### PR TITLE
Max cmd len and sftpwrite

### DIFF
--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -72,6 +72,7 @@ typedef struct _SCREEN_RECORD{
 }SCREEN_RECORD,*PSCREEN_RECORD;
 
 PSCREEN_RECORD pSavedScreenRec = NULL;
+int in_raw_mode = 0;
 
 /* ************************************************************ */
 /* Function: ConInit         									*/
@@ -121,6 +122,7 @@ int ConInit( DWORD OutputHandle, BOOL fSmartInit )
     if (GetConsoleScreenBufferInfo(hOutputConsole, &csbi))
         SavedViewRect = csbi.srWindow;
 
+	in_raw_mode = 1;
     return 0;
 }
 
@@ -133,6 +135,7 @@ int ConUnInit( void )
 {
     CONSOLE_SCREEN_BUFFER_INFO ConsoleInfo;
 
+	in_raw_mode = 0;
     if ( hOutputConsole == NULL )
         return 0;
 

--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -1069,15 +1069,15 @@ int start_with_pty(int ac, wchar_t **av) {
     /*TODO - pick this up from system32*/
     cmd[0] = L'\0';
     if (ac)
-	GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, L"cmd.exe"));
+	GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, L"cmd.exe"));
 
     ac--;
     av++;
     if (ac)
-        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, L" /c"));
+        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, L" /c"));
     while (ac) {
-        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, L" "));
-        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, *av));
+        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, L" "));
+        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, *av));
         ac--;
         av++;
     }
@@ -1183,14 +1183,14 @@ int start_withno_pty(int ac, wchar_t **av) {
 
         /*TODO - pick this up from system32*/
         cmd[0] = L'\0';
-        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, L"cmd.exe"));
+        GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, L"cmd.exe"));
         ac -= 2;
         av += 2;
         if (ac)
-                GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, L" /c"));
+                GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, L" /c"));
         while (ac) {
-                GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, L" "));
-                GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, PATH_MAX, *av));
+                GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, L" "));
+                GOTO_CLEANUP_ON_ERR(wcscat_s(cmd, MAX_CMD_LEN, *av));
                 ac--;
                 av++;
         }

--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -140,9 +140,9 @@ static DWORD WINAPI WriteThread(
 		write_status.transferred = write_status.to_transfer;
     } else {
 		/* console mode */
-        telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
-        /*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
-        write_status.transferred = write_status.to_transfer;
+		telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
+		/*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
+		write_status.transferred = write_status.to_transfer;
     }
 
 	if (0 == QueueUserAPC(WriteAPCProc, main_thread, (ULONG_PTR)pio)) {

--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -6,6 +6,8 @@
 
 #define TERM_IO_BUF_SIZE 2048
 
+extern int in_raw_mode;
+
 struct io_status {
 	DWORD to_transfer;
 	DWORD transferred;
@@ -129,25 +131,19 @@ static DWORD WINAPI WriteThread(
         DWORD dwSavedAttributes = ENABLE_PROCESSED_INPUT;
 	debug3("TermWrite thread, io:%p", pio);
 	
-        /* decide to call parsing engine or directly write to console
-         * doing the following trick to decide -
-         * if console in handle is set to process Ctrl+C, then it is likely
-         * serving a PTY enabled session 
-         */ 
-        GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &dwSavedAttributes);
-        if (dwSavedAttributes & ENABLE_PROCESSED_INPUT) {
+    if (in_raw_mode == 0) {
 		/* convert stream to utf16 and dump on console */
 		pio->write_details.buf[write_status.to_transfer] = '\0';
 		wchar_t* t = utf8_to_utf16(pio->write_details.buf);
 		WriteConsoleW(WINHANDLE(pio), t, wcslen(t), 0, 0);
 		free(t);
 		write_status.transferred = write_status.to_transfer;
-        } else {
-
-                telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
-                /*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
-                write_status.transferred = write_status.to_transfer;
-        }
+    } else {
+		// console mode
+        telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
+        /*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
+        write_status.transferred = write_status.to_transfer;
+    }
 
 	if (0 == QueueUserAPC(WriteAPCProc, main_thread, (ULONG_PTR)pio)) {
 		debug("TermWrite thread - ERROR QueueUserAPC failed %d, io:%p", GetLastError(), pio);

--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -139,7 +139,8 @@ static DWORD WINAPI WriteThread(
 		free(t);
 		write_status.transferred = write_status.to_transfer;
     } else {
-        telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen); // console mode
+		/* console mode */
+        telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
         /*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
         write_status.transferred = write_status.to_transfer;
     }

--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -139,8 +139,7 @@ static DWORD WINAPI WriteThread(
 		free(t);
 		write_status.transferred = write_status.to_transfer;
     } else {
-		// console mode
-        telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
+        telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen); // console mode
         /*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
         write_status.transferred = write_status.to_transfer;
     }

--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -139,10 +139,10 @@ static DWORD WINAPI WriteThread(
 		free(t);
 		write_status.transferred = write_status.to_transfer;
     } else {
-		/* console mode */
-		telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
-		/*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
-		write_status.transferred = write_status.to_transfer;
+        /* console mode */
+        telProcessNetwork(pio->write_details.buf, write_status.to_transfer, &respbuf, &resplen);
+        /*TODO - respbuf is not null in some cases, this needs to be returned back via read stream*/
+        write_status.transferred = write_status.to_transfer;
     }
 
 	if (0 == QueueUserAPC(WriteAPCProc, main_thread, (ULONG_PTR)pio)) {

--- a/sftp.c
+++ b/sftp.c
@@ -928,11 +928,11 @@ do_ls_dir(struct sftp_conn *conn, const char *path,
 #ifdef WINDOWS
 			/* cannot use printf_utf8 becuase of width specification */
 			/* printf_utf8 does not account for utf-16 based argument widths */
+			char *p = NULL;
 			wchar_t buf[1024]; 
 			wchar_t* wtmp = utf8_to_utf16(fname);
 			swprintf(buf, 1024, L"%-*s", colspace, wtmp);
-
-			char *p = NULL;
+			
 			if ((p = utf16_to_utf8(buf)) == NULL)
 				continue;
 			
@@ -1028,10 +1028,11 @@ do_globbed_ls(struct sftp_conn *conn, const char *path,
 #ifdef WINDOWS
 			/* cannot use printf_utf8 becuase of width specification */
 			/* printf_utf8 does not account for utf-16 based argument widths */
+			char *p = NULL;
 			wchar_t buf[1024];
 			wchar_t* wtmp = utf8_to_utf16(fname);
 			swprintf(buf, 1024, L"%-*s", colspace, wtmp);
-			char *p = NULL;
+			
 			if ((p = utf16_to_utf8(buf)) == NULL)
 				continue;
 

--- a/sftp.c
+++ b/sftp.c
@@ -296,16 +296,16 @@ help(void)
 /* printf version to account for utf-8 input */
 /* TODO - merge this with vfmprint */
 static void printf_utf8(char *fmt,  ... ) {
-    /* TODO - is 1024 sufficient */
-    char buf[1024];        
+	/* TODO - is 1024 sufficient */
+	char buf[1024];
 	int length = 0;
+	
 	va_list valist;
-    va_start(valist, fmt);
+	va_start(valist, fmt);
+	length = vsnprintf(buf, 1024, fmt, valist);
+	va_end(valist);
 
-    length = vsnprintf(buf, 1024, fmt, valist);
-    va_end(valist);
-
-    write(STDOUT_FILENO, buf, length);        
+	write(STDOUT_FILENO, buf, length);
 }
 
 /* override mprintf */


### PR DESCRIPTION
1) bug #488 -ssh in non-interactive mode silently ignores commands with length >= 260 characters
2) bug #495 - sftp batch mode output is not redirected to a file
3) identify the console terminal, pseudo terminal using the flag (in_raw_mode) initialized in the console.c