### PR TITLE
SCP bug fix: SCP does not copy file exceeds 2,147,483,648 bytes. (https://github.com/PowerShell/Win32-OpenSSH/issues/145)

### DIFF
--- a/contrib/win32/openssh/appveyor.psm1
+++ b/contrib/win32/openssh/appveyor.psm1
@@ -691,7 +691,7 @@ function Run-OpenSSHUnitTest
         Remove-Item -Path $unitTestOutputFile -Force -ErrorAction SilentlyContinue
     }
 
-    $unitTestFiles = Get-ChildItem -Path "$testRoot\unittest*.exe" -Exclude unittest-kex.exe,unittest-sshkey.exe
+    $unitTestFiles = Get-ChildItem -Path "$testRoot\unittest*.exe" -Exclude unittest-kex.exe,unittest-hostkeys.exe
     $testfailed = $false
     if ($unitTestFiles -ne $null)
     {        

--- a/contrib/win32/openssh/appveyor.psm1
+++ b/contrib/win32/openssh/appveyor.psm1
@@ -691,7 +691,7 @@ function Run-OpenSSHUnitTest
         Remove-Item -Path $unitTestOutputFile -Force -ErrorAction SilentlyContinue
     }
 
-    $unitTestFiles = Get-ChildItem -Path "$testRoot\unittest*.exe" -Exclude unittest-kex.exe
+    $unitTestFiles = Get-ChildItem -Path "$testRoot\unittest*.exe" -Exclude unittest-kex.exe,unittest-sshkey.exe
     $testfailed = $false
     if ($unitTestFiles -ne $null)
     {        

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -40,7 +40,7 @@ Pop-Location
 
 if(-not (test-path $logsdir -PathType Container))
 {
-    New-Item $logsdir -Force -ErrorAction Stop
+    $null = New-Item $logsdir -ItemType Directory -Force -ErrorAction Stop
 }
 $rights = [System.Security.AccessControl.FileSystemRights]"Read, Write"
 $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($account, $rights, "ContainerInherit,ObjectInherit", "None", "Allow")

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -38,7 +38,10 @@ cd $scriptdir
 cmd.exe /c $ntrights
 Pop-Location
 
-mkdir $logsdir > $null
+if(-not (test-path $logsdir -PathType Container))
+{
+    New-Item $logsdir -Force -ErrorAction Stop
+}
 $rights = [System.Security.AccessControl.FileSystemRights]"Read, Write"
 $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($account, $rights, "ContainerInherit,ObjectInherit", "None", "Allow")
 $acl = Get-Acl -Path $logsdir

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -812,9 +812,10 @@ int w32_allocate_fd_for_handle(HANDLE h, BOOL is_sock) {
 
 int 
 w32_ftruncate(int fd, off_t length) {
-    CHECK_FD(fd);
-
 	LARGE_INTEGER new_postion;
+
+	CHECK_FD(fd);
+
 	memset(&new_postion, 0, sizeof(new_postion));
 	new_postion.QuadPart = length;
     if (!SetFilePointerEx(w32_fd_to_handle(fd), new_postion, 0, FILE_BEGIN))

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -818,17 +818,17 @@ w32_ftruncate(int fd, off_t length) {
 
 	memset(&new_postion, 0, sizeof(new_postion));
 	new_postion.QuadPart = length;
-    if (!SetFilePointerEx(w32_fd_to_handle(fd), new_postion, 0, FILE_BEGIN))
-        return -1;
-    if (!SetEndOfFile(w32_fd_to_handle(fd)))
-        return -1;
+	if (!SetFilePointerEx(w32_fd_to_handle(fd), new_postion, 0, FILE_BEGIN))
+		return -1;
+	if (!SetEndOfFile(w32_fd_to_handle(fd)))
+		return -1;
 
-    return 0;
+	return 0;
 }
 
 int 
 w32_fsync(int fd) {
-    CHECK_FD(fd);
+	CHECK_FD(fd);
 
-    return FlushFileBuffers(w32_fd_to_handle(fd));
+	return FlushFileBuffers(w32_fd_to_handle(fd));
 }

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -816,7 +816,6 @@ w32_ftruncate(int fd, off_t length) {
 
 	CHECK_FD(fd);
 
-	memset(&new_postion, 0, sizeof(new_postion));
 	new_postion.QuadPart = length;
 	if (!SetFilePointerEx(w32_fd_to_handle(fd), new_postion, 0, FILE_BEGIN))
 		return -1;

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -814,7 +814,10 @@ int
 w32_ftruncate(int fd, off_t length) {
     CHECK_FD(fd);
 
-    if (!SetFilePointer(w32_fd_to_handle(fd), length, 0, FILE_BEGIN))
+	LARGE_INTEGER new_postion;
+	memset(&new_postion, 0, sizeof(new_postion));
+	new_postion.QuadPart = length;
+    if (!SetFilePointerEx(w32_fd_to_handle(fd), new_postion, 0, FILE_BEGIN))
         return -1;
     if (!SetEndOfFile(w32_fd_to_handle(fd)))
         return -1;


### PR DESCRIPTION
1. update the install-sshd does not failed when log folder exists.
2. enable to copy files larger than 2G