### PR TITLE
strip drive letter from %HOMEPATH%

### DIFF
--- a/session.c
+++ b/session.c
@@ -410,14 +410,16 @@ static void setup_session_vars(Session* s) {
 		UTF8_TO_UTF16_FATAL(tmp, s->display);
 		SetEnvironmentVariableW(L"DISPLAY", tmp);
 	}
-	SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w);
 	SetEnvironmentVariableW(L"USERPROFILE", pw_dir_w);
 
-	if (pw_dir_w[1] == L':') {
+	if (pw_dir_w[0] && pw_dir_w[1] == L':') {
+		SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w + 2);
 		wchar_t wc = pw_dir_w[2];
 		pw_dir_w[2] = L'\0';
 		SetEnvironmentVariableW(L"HOMEDRIVE", pw_dir_w);
 		pw_dir_w[2] = wc;
+	} else {
+		SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w);
 	}
 
 	snprintf(buf, sizeof buf, "%.50s %d %d",


### PR DESCRIPTION
Many programs access the user's home directory as %HOMEDRIVE%%HOMEPATH%.

Without removing the drive letter from %HOMEPATH%, the result of this
concatenation is something like "C:C:\Users\mgkuhn" and results
in applications not finding the home directory.

After this change, OpenSSH will set %HOMEPATH% without a drive letter,
like Windows does, as documented at

  https://support.microsoft.com/en-us/help/101507/how-windows-nt-determines-a-user-s-home-directory

I also added a safety check to test that pw_dir_w is not empty.