### PR TITLE
shell: Cleanup shellhost (use func SendKeyStroke)

### DIFF
--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -86,17 +86,17 @@ typedef struct consoleEvent {
 } consoleEvent;
 
 struct key_translation {
-	char incoming[5];
+	char incoming[6];
 	int vk;
-	char outgoing[1];
+	char outgoing;
 } key_translation;
 
 struct key_translation keys[] = {
-    { "\x1b",       VK_ESCAPE,  "\x1b" },
-    { "\r",         VK_RETURN,  "\r" },
-    { "\b",         VK_BACK,    "\b" },
-    { "\x7f",       VK_BACK,    "\b" },
-    { "\t",         VK_TAB,     "\t" },
+    { "\x1b",       VK_ESCAPE,  '\x1b' },
+    { "\r",         VK_RETURN,  '\r' },
+    { "\b",         VK_BACK,    '\b' },
+    { "\x7f",       VK_BACK,    '\b' },
+    { "\t",         VK_TAB,     '\t' },
     { "\x1b[A",     VK_UP,       0 },
     { "\x1b[B",     VK_DOWN,     0 },
     { "\x1b[C",     VK_RIGHT,    0 },
@@ -230,7 +230,7 @@ ProcessIncomingKeys(char * ansikey)
 
 	for (int nKey=0; nKey < ARRAYSIZE(keys); nKey++) {
 		if (strcmp(ansikey, keys[nKey].incoming) == 0) {
-			SendKeyStroke(child_in, keys[nKey].vk, keys[nKey].outgoing[0]);
+			SendKeyStroke(child_in, keys[nKey].vk, keys[nKey].outgoing);
 			return;
 		}
 	}


### PR DESCRIPTION
Cleanup code and fix IntelliSense error:
> a value of type "const char [6]" cannot be used to initialize an entity of type "char [5]"