### PR TITLE
win32: Fix execute SSHD child process with any module name

### DIFF
--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -4,6 +4,13 @@
 #define SSH_ASYNC_STDOUT "SSH_ASYNC_STDOUT"
 #define SSH_ASYNC_STDERR "SSH_ASYNC_STDERR"
 
+#define GOTO_CLEANUP_IF(_cond_,_err_) do {  \
+    if ((_cond_)) {                         \
+        hr = _err_;                         \
+        goto cleanup;                       \
+    }                                       \
+} while(0)
+
 /* removes first '/' for Windows paths that are unix styled. Ex: /c:/ab.cd */
 char * sanitized_path(const char *);
 

--- a/regress/pesterTests/SCP.Tests.ps1
+++ b/regress/pesterTests/SCP.Tests.ps1
@@ -154,7 +154,12 @@ Describe "Tests for scp command" -Tags "CI" {
 
     It 'File copy: <Title> ' -TestCases:$testData {
         param([string]$Title, $Source, $Destination, $Options)
-            
+
+        Write-Host "Src: $Source" -ForegroundColor Yellow
+        Write-BuildMessage "Src: $Source" -Category Information
+        Write-Host "Dst: $Destination" -ForegroundColor Yellow
+        Write-BuildMessage "Dst: $Destination" -Category Information
+        
         iex  "scp $Options $Source $Destination"
         $LASTEXITCODE | Should Be 0
         #validate file content. DestPath is the path to the file.

--- a/scp.c
+++ b/scp.c
@@ -295,7 +295,7 @@ do_cmd(char *host, char *remuser, char *cmd, int *fdin, int *fdout)
 	fcntl(pout[0], F_SETFD, FD_CLOEXEC);
 	fcntl(pin[1], F_SETFD, FD_CLOEXEC);
 
-	do_cmd_pid = spawn_child(args.list[0], args.list + 1, pin[0], pout[1], STDERR_FILENO, 0);
+	do_cmd_pid = spawn_child(NULL, args.list, pin[0], pout[1], STDERR_FILENO, 0);
 
 #else /* !WINDOWS */
 	do_cmd_pid = fork();
@@ -364,7 +364,7 @@ do_cmd2(char *host, char *remuser, char *cmd, int fdin, int fdout)
 	addargs(&args, "%s", host);
 	addargs(&args, "%s", cmd);
 
-	pid = spawn_child(args.list[0], args.list + 1, fdin, fdout, STDERR_FILENO, 0);
+	pid = spawn_child(NULL, args.list, fdin, fdout, STDERR_FILENO, 0);
 		
 #else /* !WINDOWS */
 	pid = fork();

--- a/sftp.c
+++ b/sftp.c
@@ -2259,7 +2259,7 @@ connect_to_server(char *path, char **args, int *in, int *out)
 	fcntl(pout[1], F_SETFD, FD_CLOEXEC);
 	fcntl(pin[0], F_SETFD, FD_CLOEXEC);
 
-	sshpid = spawn_child(path, args + 1, c_in, c_out, STDERR_FILENO, 0);
+	sshpid = spawn_child(path, args, c_in, c_out, STDERR_FILENO, 0);
 	if (sshpid == -1)
 #else /* !WINDOWS */
 	if ((sshpid = fork()) == -1)

--- a/sshd.c
+++ b/sshd.c
@@ -1299,13 +1299,9 @@ server_accept_loop(int *sock_in, int *sock_out, int *newsock, int *config_s)
 			* - Spawn child sshd.exe
 			*/
 			{
-				char* path_utf8 = utf16_to_utf8(GetCommandLineW());
 				/* large enough to hold pointer value in hex */
 				char fd_handle[30];  
 
-				if (path_utf8 == NULL)
-					fatal("Failed to alloc memory");
-				
 				if (snprintf(fd_handle, sizeof(fd_handle), "%p", 
 					w32_fd_to_handle(*newsock)) == -1
 				    || SetEnvironmentVariable("SSHD_REMSOC", fd_handle) == FALSE
@@ -1320,12 +1316,10 @@ server_accept_loop(int *sock_in, int *sock_out, int *newsock, int *config_s)
 					 * automatically be cleaned up on next iteration
 					 */
 					close(startup_p[1]);
-					free(path_utf8);
 					continue;
 				}
                 
-				pid = spawn_child(path_utf8, NULL, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO, CREATE_NEW_PROCESS_GROUP);
-				free(path_utf8);
+				pid = spawn_child(NULL, NULL, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO, CREATE_NEW_PROCESS_GROUP);
 				close(*newsock);
 			}
 #else /* !WINDOWS */


### PR DESCRIPTION
If run main process as `C:\sshd>"sshd.exe"↲` (look for quotes) then child process **sshd.exe** can't executed.
If main module have name with space (like `sshd v75.exe`) then child process **sshd v75.exe** can't executed.

It's now we have this error on run new SSH-session:
`debug3: spawning C:\sshd\"sshd v75.exe"  -ddddddddddd -f sshd_config`
After merge this commit:
`debug3: spawning "C:\sshd\sshd v75.exe" "-ddddddddddd" "-f" "sshd_config"`