### PR TITLE
Fix RegEnumValueW returned 234

### DIFF
--- a/session.c
+++ b/session.c
@@ -343,17 +343,17 @@ static void setup_session_user_vars(Session* s)	/* set user environment variable
 		ret = RegEnumValueW(reg_key, i++, name, &name_chars, 0, &type, (LPBYTE)data, &required);
 		if (ret == ERROR_NO_MORE_ITEMS)
 			break;
-		else if (ret != ERROR_SUCCESS) {
-			error("Error retrieving user environment variables. RegEnumValueW returned %d", ret);
-			break;
-		}
-		else if (required > data_chars * 2) {
+		else if (ret == ERROR_MORE_DATA || required > data_chars * 2) {
 			if (data != NULL)
 				free(data);
 			data = xmalloc(required);
 			data_chars = required/2;
 			i--;
 			continue;
+		}
+		else if (ret != ERROR_SUCCESS) {
+			error("Error retrieving user environment variables. RegEnumValueW returned %d", ret);
+			break;
 		}
 
 		if (type == REG_SZ)


### PR DESCRIPTION
RegEnumValueW may return ERROR_MORE_DATA (234).
If lpData is NULL and lpcbData is non-NULL, the function stores the size of the data, in bytes, in the variable pointed to by lpcbData. This enables an application to determine the best way to allocate a buffer for the data.
If the buffer specified by lpData is not large enough to hold the data, the function returns ERROR_MORE_DATA and stores the required buffer size in the variable pointed to by lpcbData. In this case, the contents of lpData are undefined.