### PR TITLE
Fixed ACLs already contain SIDS under Nano

### DIFF
--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -342,7 +342,14 @@ function Repair-FilePermissionInternal {
 
     foreach($a in $acl.Access)
     {
-        $IdentityReferenceSid = Get-UserSid -User $a.IdentityReference
+        if ($a.IdentityReference -is [System.Security.Principal.SecurityIdentifier]) 
+        {
+            $IdentityReferenceSid = $a.IdentityReference
+        }
+        Else 
+        {
+            $IdentityReferenceSid = Get-UserSid -User $a.IdentityReference
+        }
         if($IdentityReferenceSid -eq $null)
         {
             $idRefShortValue = ($a.IdentityReference.Value).split('\')[-1]


### PR DESCRIPTION
This appears to fix https://github.com/PowerShell/Win32-OpenSSH/issues/794.
After modifications were made, retested under Windows 10 and Windows 7 and retested uninstall on both those and Nano.