### PR TITLE
SETTING term=XTERM

### DIFF
--- a/contrib/win32/win32compat/wmain_common.c
+++ b/contrib/win32/win32compat/wmain_common.c
@@ -53,6 +53,9 @@ wmain(int argc, wchar_t **wargv) {
 	if (getenv("SSH_AUTH_SOCK") == NULL)
 		_putenv("SSH_AUTH_SOCK=\\\\.\\pipe\\openssh-ssh-agent");
 
+	if (getenv("TERM") == NULL)
+		_putenv("TERM=xterm");
+
 	w32posix_initialize();
 	
 	r = main(argc, argv);


### PR DESCRIPTION
set the TERM to "xterm", if it is not set. This is the request from the community as majority of the windows users doesn't aware of setting the TERM.

https://github.com/PowerShell/Win32-OpenSSH/issues/252