### PR TITLE
OpenSSHUtils ProfilePath parsing issues

### DIFF
--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -168,7 +168,9 @@ function Repair-AuthorizedKeyPermission
                 $userProfilePath =  $properties.ProfileImagePath
             }
             $userProfilePath = $userProfilePath.Replace("\", "\\")
-            $fullPath -match "^$userProfilePath[\\|\W|\w]+authorized_keys$"
+            if ( $properties.PSChildName -notmatch '\.bak$') {
+                $fullPath -match "^$userProfilePath[\\|\W|\w]+authorized_keys$"
+            }
         }
         if($profileItem)
         {

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -169,7 +169,7 @@ function Repair-AuthorizedKeyPermission
             }
             $userProfilePath = $userProfilePath.Replace("\", "\\")
             if ( $properties.PSChildName -notmatch '\.bak$') {
-                $fullPath -match "^$userProfilePath[\\|\W|\w]+authorized_keys$"
+                $fullPath -match "^$userProfilePath\\[\\|\W|\w]+authorized_keys$"
             }
         }
         if($profileItem)


### PR DESCRIPTION
Hi,

Regarding the authorized_keys permission fix bits:
I found out that in case there's more than one entry in the registry that matches the regex, then it will throw an exception as it appends all the matching registry paths to the profileItem variable, which won't be a valid registry entry that has a PSChildName field (thus the exception).

- If you delete the home dir of an user, then login via ssh, windows will append ".bak" to the user's profileList entry's name. If you recreate the user, it will have a new profileList entry, but with the same path.
- If you have multiple users that share the first part of their username/path, then the shortest user's regex will match all of them.

Regards,
David

p.s.: the original converstion can be found at https://github.com/PowerShell/Win32-OpenSSH/pull/843