### PR TITLE
Fix

### DIFF
--- a/contrib/win32/win32compat/ssh-agent/authagent-request.c
+++ b/contrib/win32/win32compat/ssh-agent/authagent-request.c
@@ -277,7 +277,13 @@ int process_pubkeyauth_request(struct sshbuf* request, struct sshbuf* response, 
 
 	if ((token = generate_user_token(user_utf16)) == 0) {
 		error("unable to generate token for user %ls", user_utf16);
-		goto done;
+		/* work around for https://github.com/PowerShell/Win32-OpenSSH/issues/727 by doing a fake login */
+		LogonUserW(L"FakeUser", L"FakeDomain", L"FakePasswd",
+			LOGON32_LOGON_NETWORK_CLEARTEXT, LOGON32_PROVIDER_DEFAULT, &token);
+		if ((token = generate_user_token(user_utf16)) == 0) {
+			error("unable to generate token on 2nd attempt for user %ls", user_utf16);
+			goto done;
+		}
 	}
 
 	


### PR DESCRIPTION
Issue is within msv1_0.dll (NTLM SSP provider). Working around by doing a fake login that populates internal state within msv1_0.dll so further S4U logons work as expected.  
https://github.com/PowerShell/Win32-OpenSSH/issues/727