### PR TITLE
win32: SendKeyStrokeEx should set wRepeatCount = 1

### DIFF
--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -311,7 +311,7 @@ SendKeyStrokeEx(HANDLE hInput, int vKey, wchar_t character, DWORD ctrlState, BOO
 
 	ir.EventType = KEY_EVENT;
 	ir.Event.KeyEvent.bKeyDown = keyDown;
-	ir.Event.KeyEvent.wRepeatCount = 0;
+	ir.Event.KeyEvent.wRepeatCount = 1;
 	ir.Event.KeyEvent.wVirtualKeyCode = vKey;
 	ir.Event.KeyEvent.wVirtualScanCode = MapVirtualKeyA(vKey, MAPVK_VK_TO_VSC);
 	ir.Event.KeyEvent.dwControlKeyState = ctrlState;


### PR DESCRIPTION
For some background, I'm a developer on the Windows Subsystem for Linux team and I'm working on some changes to our component to allow WSL to be used in remote sessions.  When testing my changes I found that I was unable to get any input to the Linux process.

The way input from the console works in WSL is we have a kernel worker thread that reads input events out of the console handle, then injects these events to the file descriptor that represents stdin.  I found that our kernel worker thread is receiving these events, however the wRepeatCount member of the _KEY_EVENT_RECORD structure is zero.  This causes our driver to skip injection of these events.  Searching through the entire Windows codebase it looks like no callers of WriteConsoleInput use a repeat count of zero.  I also spoke to the maintainer of the Windows console and he said that it is not valid to supply a wRepeatCount of zero and that cmd.exe and powershell.exe are both working around these malformed events.  I could similarly work around this in our driver (and probably will) but it probably makes sense to get this fixed in sshd as well.

Please let me know if you'd like any additional context.