### PR TITLE
fix forwardslash issue

### DIFF
--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -164,7 +164,6 @@ struct key_translation keys[] = {
     { L"\x1bOQ",     VK_F2,       0 , 0 , 0},
     { L"\x1bOR",     VK_F3,       0 , 0 , 0},
     { L"\x1bOS",     VK_F4,       0 , 0 , 0},
-    { L"\x1b?",      VK_OEM_2, L'?' , 0 , SHIFT_PRESSED | LEFT_ALT_PRESSED},
     { L"\x1",        VK_A,   L'\x1' , 0 , LEFT_CTRL_PRESSED},
     { L"\x2",        VK_B,   L'\x2' , 0 , LEFT_CTRL_PRESSED},
     //{ L"\x3",        VK_C,   L'\x3' , 0 , LEFT_CTRL_PRESSED}, /* Control + C is handled differently */

--- a/contrib/win32/win32compat/tncon.c
+++ b/contrib/win32/win32compat/tncon.c
@@ -208,9 +208,6 @@ ReadConsoleForTermEmul(HANDLE hInput, char *destin, int destinlen)
 					case VK_ESCAPE:
 						NetWriteString2(pParams->Socket, (char *)ESCAPE_KEY, 1, 0);
 						break;
-					case VK_OEM_2:
-						NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_Q, 2, 0);
-						break;
 					case VK_SHIFT:
 					case VK_CONTROL:
 					case VK_CAPITAL:


### PR DESCRIPTION
Issue - https://github.com/PowerShell/Win32-OpenSSH/issues/858

VTSequence to interpret alt+? is dependent on the key board type so removing this code..
https://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx

Because of this, powershell shortcut alt+? will not work... 

