### PR TITLE
fix scp build issue, fix new warning msg in posixcompat

### DIFF
--- a/contrib/win32/openssh/scp.vcxproj
+++ b/contrib/win32/openssh/scp.vcxproj
@@ -134,6 +134,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir);$(LibreSSL-Path)include;$(OpenSSH-Src-Path)includes;$(OpenSSH-Src-Path);$(OpenSSH-Src-Path)contrib\win32\win32compat;$(OpenSSH-Src-Path)libkrb;$(OpenSSH-Src-Path)libkrb\libKrb5;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <VersionHelpers.h>
+
 #define PATH_MAX MAX_PATH
 #define SSH_ASYNC_STDIN "SSH_ASYNC_STDIN"
 #define SSH_ASYNC_STDOUT "SSH_ASYNC_STDOUT"


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/889

1) SCP build is failing.
Error	D8016	'/ZI' and '/guard:cf' command-line options are incompatible	

2) Fix the new warning message
Warning	C4013	'IsWindows8OrGreater' undefined; assuming extern returning int	posix_compat	E:\balu\Microsoft\Powershell\Code\openssh-portable\\contrib\win32\win32compat\termio.c	261	
