### PR TITLE
Multiple fixes

### DIFF
--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -514,6 +514,9 @@ ConWriteString(char* pszString, int cbString)
 	int cnt = 0;
 	wchar_t* utf16 = NULL;
 
+	if (pszString == NULL)
+		return 0;
+
 	if ((needed = MultiByteToWideChar(CP_UTF8, 0, pszString, cbString, NULL, 0)) == 0 ||
 	    (utf16 = malloc(needed * sizeof(wchar_t))) == NULL ||
 	    (cnt = MultiByteToWideChar(CP_UTF8, 0, pszString, cbString, utf16, needed)) == 0) {
@@ -535,6 +538,9 @@ int
 ConTranslateAndWriteString(char* pszString, int cbString)
 {
 	DWORD Result = 0;
+
+	if (pszString == NULL)
+		return 0;
 
 	if (hOutputConsole)
 		WriteConsole(hOutputConsole, pszString, cbString, &Result, 0);

--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -514,9 +514,6 @@ ConWriteString(char* pszString, int cbString)
 	int cnt = 0;
 	wchar_t* utf16 = NULL;
 
-	if (pszString == NULL)
-		return 0;
-
 	if ((needed = MultiByteToWideChar(CP_UTF8, 0, pszString, cbString, NULL, 0)) == 0 ||
 	    (utf16 = malloc(needed * sizeof(wchar_t))) == NULL ||
 	    (cnt = MultiByteToWideChar(CP_UTF8, 0, pszString, cbString, utf16, needed)) == 0) {
@@ -538,9 +535,6 @@ int
 ConTranslateAndWriteString(char* pszString, int cbString)
 {
 	DWORD Result = 0;
-
-	if (pszString == NULL)
-		return 0;
 
 	if (hOutputConsole)
 		WriteConsole(hOutputConsole, pszString, cbString, &Result, 0);

--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -347,7 +347,11 @@ createFile_flags_setup(int flags, mode_t mode, struct createFile_flags* cf_flags
 	// If the mode is USHRT_MAX then we will inherit the permissions from the parent folder.
 	if (mode != USHRT_MAX) {
 		/*validate mode*/
-		if (mode & ~(S_IRWXU | S_IRWXG | S_IRWXO)) {
+		/*
+		 * __S_IFDIR  __S_IFREG are added for compat
+		 * TODO- open(__S_IFDIR) on a file and vice versa should fail
+		*/
+		if (mode & ~(S_IRWXU | S_IRWXG | S_IRWXO | __S_IFDIR | __S_IFREG)) {
 			debug3("open - ERROR: unsupported mode: %d", mode);
 			errno = ENOTSUP;
 			return -1;

--- a/contrib/win32/win32compat/inc/fcntl.h
+++ b/contrib/win32/win32compat/inc/fcntl.h
@@ -59,3 +59,10 @@ int w32_allocate_fd_for_handle(HANDLE, BOOL);
 # define S_IRWXU			0000700	/* read, write, execute */
 # define S_IRWXG			0000070	/* read, write, execute */
 # define S_IRWXO			0000007	/* read, write, execute */
+
+/* 
+ * File types. Note that the values are different from similar variants 
+ * defined in stat.h. These are based on similar definition values on Linux
+ */
+#define __S_IFDIR       0040000 /* Directory.  */
+#define __S_IFREG       0100000 /* Regular file.  */


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/894
- Added logic to profile path retrieval to consider environment variables in path read from registry

https://github.com/PowerShell/Win32-OpenSSH/issues/883
- Added flags to support libssh2 SFTP. These are No-Ops for now. We may support them later if needed. Added https://github.com/PowerShell/Win32-OpenSSH/issues/915 to keep track of TODO work item