### PR TITLE
SFTP fix to download a very large file in chunks #863

### DIFF
--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -810,7 +810,7 @@ cleanup:
 }
 
 long
-fileio_lseek(struct w32_io* pio, unsigned long long int offset, int origin)
+fileio_lseek(struct w32_io* pio, unsigned __int64 offset, int origin)
 {
 	debug4("lseek - pio:%p", pio);
 	if (origin != SEEK_SET) {

--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -810,7 +810,7 @@ cleanup:
 }
 
 long
-fileio_lseek(struct w32_io* pio, long offset, int origin)
+fileio_lseek(struct w32_io* pio, unsigned long long int offset, int origin)
 {
 	debug4("lseek - pio:%p", pio);
 	if (origin != SEEK_SET) {
@@ -819,8 +819,9 @@ fileio_lseek(struct w32_io* pio, long offset, int origin)
 		return -1;
 	}
 
-	pio->read_overlapped.Offset = offset;
-	pio->write_overlapped.Offset = offset;
+	pio->write_overlapped.Offset = pio->read_overlapped.Offset = offset & 0xffffffff;
+	pio->write_overlapped.OffsetHigh = pio->read_overlapped.OffsetHigh = (offset & 0xffffffff00000000) >> 32;
+	 
 	return 0;
 }
 

--- a/contrib/win32/win32compat/inc/unistd.h
+++ b/contrib/win32/win32compat/inc/unistd.h
@@ -46,7 +46,7 @@ int w32_dup2(int oldfd, int newfd);
 unsigned int w32_alarm(unsigned int seconds);
 #define alarm w32_alarm
 
-long w32_lseek(int fd, long offset, int origin);
+long w32_lseek(int fd, unsigned long long int offset, int origin);
 #define lseek w32_lseek
 
 #define getdtablesize() MAX_FDS

--- a/contrib/win32/win32compat/inc/unistd.h
+++ b/contrib/win32/win32compat/inc/unistd.h
@@ -46,7 +46,7 @@ int w32_dup2(int oldfd, int newfd);
 unsigned int w32_alarm(unsigned int seconds);
 #define alarm w32_alarm
 
-long w32_lseek(int fd, unsigned long long int offset, int origin);
+long w32_lseek(int fd, unsigned __int64 offset, int origin);
 #define lseek w32_lseek
 
 #define getdtablesize() MAX_FDS

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -484,7 +484,7 @@ w32_fstat(int fd, struct w32_stat *buf)
 }
 
 long
-w32_lseek(int fd, unsigned long long int offset, int origin)
+w32_lseek(int fd, unsigned __int64 offset, int origin)
 {
 	CHECK_FD(fd);
 	return fileio_lseek(fd_table.w32_ios[fd], offset, origin);

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -484,7 +484,7 @@ w32_fstat(int fd, struct w32_stat *buf)
 }
 
 long
-w32_lseek(int fd, long offset, int origin)
+w32_lseek(int fd, unsigned long long int offset, int origin)
 {
 	CHECK_FD(fd);
 	return fileio_lseek(fd_table.w32_ios[fd], offset, origin);

--- a/contrib/win32/win32compat/w32fd.h
+++ b/contrib/win32/win32compat/w32fd.h
@@ -150,5 +150,5 @@ int fileio_read(struct w32_io* pio, void *dst, size_t max);
 int fileio_write(struct w32_io* pio, const void *buf, size_t max);
 int fileio_fstat(struct w32_io* pio, struct _stat64 *buf);
 int fileio_stat(const char *path, struct _stat64 *buf);
-long fileio_lseek(struct w32_io* pio, unsigned long long int offset, int origin);
+long fileio_lseek(struct w32_io* pio, unsigned __int64 offset, int origin);
 FILE* fileio_fdopen(struct w32_io* pio, const char *mode);

--- a/contrib/win32/win32compat/w32fd.h
+++ b/contrib/win32/win32compat/w32fd.h
@@ -150,5 +150,5 @@ int fileio_read(struct w32_io* pio, void *dst, size_t max);
 int fileio_write(struct w32_io* pio, const void *buf, size_t max);
 int fileio_fstat(struct w32_io* pio, struct _stat64 *buf);
 int fileio_stat(const char *path, struct _stat64 *buf);
-long fileio_lseek(struct w32_io* pio, long offset, int origin);
+long fileio_lseek(struct w32_io* pio, unsigned long long int offset, int origin);
 FILE* fileio_fdopen(struct w32_io* pio, const char *mode);


### PR DESCRIPTION
Issue - https://github.com/PowerShell/Win32-OpenSSH/issues/863
When we try to download a large file (>4 GB) using SFTP in chunks (for every chunk we open&close the file) then the file transfer fails. Please note that if we download the file wholly (open, transfer full file, close) then it is working.

Root cause - lseek() is not populating the offsetHigh.

Testcases -
1) Verified the sftp download from UNIX machine in chunks.
2) Verified the sftp download from UNIX machine wholly.
3) Verified the sftp download from filezilla on windows machine.

