### PR TITLE
Prepare OpenSSHUtils for the Gallery

### DIFF
--- a/contrib/win32/openssh/OpenSSHUtils.psd1
+++ b/contrib/win32/openssh/OpenSSHUtils.psd1
@@ -1,44 +1,21 @@
-#
-# Module manifest for module 'OpenSSHUtils'
-#
-# Generated on: 6/9/2017
-#
-
 @{
-
-# Script module or binary module file associated with this manifest
-ModuleToProcess = 'OpenSSHUtils.psm1'
-
-# Version number of this module.
-ModuleVersion = '1.0.0.1'
-
-# ID used to uniquely identify this module
-GUID = '08285dee-3d08-476b-8948-1a7e2562c079'
-
-# Author of this module
-Author = 'Yanbing Wang'
-
-# Company or vendor of this module
-CompanyName = ''
-
-# Copyright statement for this module
-Copyright = ''
-
-# Description of the functionality provided by this module
-Description = 'Configure OpenSSH for Windows related security settings like file owner and permissions.'
-
-# Functions to export from this module
-FunctionsToExport = '*'
-
-# Cmdlets to export from this module
-CmdletsToExport = '*'
-
-# Variables to export from this module
-VariablesToExport = '*'
-
-# Aliases to export from this module
-AliasesToExport = '*'
-
-# Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '2.0'
+    ModuleToProcess = 'OpenSSHUtils.psm1'
+    ModuleVersion = '0.0.2.0'
+    GUID = '08285dee-3d08-476b-8948-1a7e2562c079'
+    Author = 'Microsoft Corporation'
+    CompanyName = 'Microsoft Corporation'
+    Copyright = '© Microsoft Corporation. All rights reserved.'
+    Description = 'Utilities and functions for configuring OpenSSH on Windows.'
+    FunctionsToExport = 'Repair-SshdConfigPermission', 'Repair-SshdHostKeyPermission', 'Repair-AuthorizedKeyPermission', 'Repair-UserKeyPermission', 'Repair-UserSshConfigPermission' 
+    CmdletsToExport= ''
+    VariablesToExport = ''
+    AliasesToExport = ''
+    PowerShellVersion = '2.0'
+    
+    PrivateData = @{
+        PSData = @{
+            Tags = @('SSH', 'OpenSSH', 'PSEdition_Desktop')
+            ProjectUri = 'https://github.com/PowerShell/Win32-OpenSSH'
+        }
+    }
 }


### PR DESCRIPTION
First, I'm not sure if moving the module into a new folder breaks all your tests and such. Please bear with me, I don't have a dev environment stood up here, and I'm going to wait to see what breaks in CI.

As for what I actually did:

* rev'd the module to 0.0.2.0
* removed some helper functions from FunctionsToExport that didn't need to be exposed to the end user

I think in the future, we should generically use `Sshd` and `Ssh` as generic noun prefixes, but I'd rather not go through that refactor right now.

FYI, I won't be publishing the helper scripts as they expect to be sitting in the root of OpenSSH binaries. Instead, I'll be publishing blog guidance based on the system32 location. In the future, we should just wrap those up as functions within the module. 