### PR TITLE
fix SCP nondefault port issue (-P option)

### DIFF
--- a/regress/pesterTests/SCP.Tests.ps1
+++ b/regress/pesterTests/SCP.Tests.ps1
@@ -149,7 +149,6 @@ Describe "Tests for scp command" -Tags "CI" {
     It 'File copy: <Title> ' -TestCases:$testData {
         param([string]$Title, $Source, $Destination, [string]$Options)
         
-        Write-Host "executing scp $Options $Source $Destination"
         iex  "scp $Options $Source $Destination"
         $LASTEXITCODE | Should Be 0
         #validate file content. DestPath is the path to the file.

--- a/regress/pesterTests/SCP.Tests.ps1
+++ b/regress/pesterTests/SCP.Tests.ps1
@@ -58,8 +58,8 @@ Describe "Tests for scp command" -Tags "CI" {
             @{
                 Title = 'simple copy local file to remote dir'         
                 Source = $SourceFilePath
-                Destination = "test_target:$DestinationDir"
-                Options = "-C -q"
+                Destination = "$ssouser`@$server`:$DestinationDir"
+                Options = "-P $port -C -q" # To test -P so not using test_target intentionally.
             },
             @{
                 Title = 'simple copy remote file to local dir'
@@ -148,7 +148,8 @@ Describe "Tests for scp command" -Tags "CI" {
 
     It 'File copy: <Title> ' -TestCases:$testData {
         param([string]$Title, $Source, $Destination, [string]$Options)
-            
+        
+        Write-Host "executing scp $Options $Source $Destination"
         iex  "scp $Options $Source $Destination"
         $LASTEXITCODE | Should Be 0
         #validate file content. DestPath is the path to the file.

--- a/scp.c
+++ b/scp.c
@@ -294,6 +294,10 @@ do_cmd(char *host, char *remuser, int port, char *cmd, int *fdin, int *fdout)
 #ifdef WINDOWS
 	/* generate command line and spawn_child */
 	replacearg(&args, 0, "%s", ssh_program);
+	if (port != -1) {
+		addargs(&args, "-p");
+		addargs(&args, "%d", port);
+	}
 	if (remuser != NULL) {
 		addargs(&args, "-l");
 		addargs(&args, "%s", remuser);

--- a/scp.c
+++ b/scp.c
@@ -377,6 +377,10 @@ do_cmd2(char *host, char *remuser, int port, char *cmd, int fdin, int fdout)
 #ifdef WINDOWS
 	/* generate command line and spawn_child */
 	replacearg(&args, 0, "%s", ssh_program);
+	if (port != -1) {
+		addargs(&args, "-p");
+		addargs(&args, "%d", port);
+	}
 	if (remuser != NULL) {
 		addargs(&args, "-l");
 		addargs(&args, "%s", remuser);


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/1006

The below command is not working as "-P <port>" is not passed to the child SCP process,
scp -P 12345 -i x:\key\mykey.key user@1.2.3.4:/home/user/upload/* x:\download