### PR TITLE
putty, cygwin, unix ssh clients are unable to show colors

### DIFF
--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -690,7 +690,7 @@ SendCharacter(HANDLE hInput, WORD attributes, wchar_t character)
 
 	StringCbPrintfExA(Next, SizeLeft, &Next, &SizeLeft, 0, ";%u", Color);
 	
-	StringCbPrintfExA(Next, SizeLeft, &Next, &SizeLeft, 0, ";%c", 'm');
+	StringCbPrintfExA(Next, SizeLeft, &Next, &SizeLeft, 0, "%c", 'm');
 
 	if (bUseAnsiEmulation && attributes != pattributes)
 		WriteFile(hInput, formatted_output, (DWORD)(Next - formatted_output), &wr, NULL);


### PR DESCRIPTION
ssh-shellhost sends "\033[0;39;24;27;31;40;mtest" but it should send "\033[0;39;24;27;31;40mtest".
There an extra ";" before "m".

https://github.com/PowerShell/Win32-OpenSSH/issues/1005