### PR TITLE
automated generation of cfg, logs folder and copy sshd_config

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1466,3 +1466,77 @@ is_absolute_path(char *path)
 	
 	return retVal;
 }
+
+/* return 0 - in case of failure */
+int
+create_directory_withsddl(char *path, char *sddl)
+{
+	struct stat st;
+	if (stat(path, &st) < 0) {
+		PSECURITY_DESCRIPTOR pSD = NULL;
+		SECURITY_ATTRIBUTES sa;
+		memset(&sa, 0, sizeof(SECURITY_ATTRIBUTES));
+		sa.nLength = sizeof(SECURITY_ATTRIBUTES);
+		sa.bInheritHandle = FALSE;
+
+		wchar_t *path_w = utf8_to_utf16(path);
+		if (!path_w) {
+			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, path);
+			return 0; /* to avoid the compiler warning */
+		}
+
+		wchar_t *sddl_w = utf8_to_utf16(sddl);
+		if (!sddl_w) {
+			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, sddl);
+			return 0; /* to avoid the compiler warning */
+		}
+
+		if (ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl_w, SDDL_REVISION, &pSD, NULL) == FALSE) {
+			error("ConvertStringSecurityDescriptorToSecurityDescriptorW failed with error code %d", GetLastError());
+			return 0;
+		}
+
+		if (IsValidSecurityDescriptor(pSD) == FALSE) {
+			error("IsValidSecurityDescriptor return FALSE");
+			return 0;
+		}
+
+		sa.lpSecurityDescriptor = pSD;
+		if (!CreateDirectoryW(path_w, &sa)) {
+			error("Failed to create directory:%ls error:%d", path_w, GetLastError());
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+/* return 0 - in case of failure */
+int
+copy_file(char *source, char *destination)
+{
+	if (!source || !destination) return 1;
+
+	struct stat st;
+	if ((stat(destination, &st) < 0) || (stat(source, &st) < 0)) {
+		wchar_t *source_w = utf8_to_utf16(source);
+		if (!source_w) {
+			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, source_w);
+			return 0; /* to avoid the compiler warning */
+		}
+
+		wchar_t *destination_w = utf8_to_utf16(destination);
+		if (!destination_w) {
+			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, destination_w);
+			return 0; /* to avoid the compiler warning */
+		}
+
+		if (!CopyFileW(source_w, destination_w, FALSE)) {
+			error("Failed to copy %ls to %ls, error:%d", source_w, destination_w, GetLastError());
+			return 0;
+		}
+	}
+
+	return 1;
+}
+

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1482,13 +1482,13 @@ create_directory_withsddl(char *path, char *sddl)
 		wchar_t *path_w = utf8_to_utf16(path);
 		if (!path_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, path);
-			return -1; /* to avoid the compiler warning */
+			return -1;
 		}
 
 		wchar_t *sddl_w = utf8_to_utf16(sddl);
 		if (!sddl_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, sddl);
-			return -1; /* to avoid the compiler warning */
+			return -1;
 		}
 
 		if (ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl_w, SDDL_REVISION, &pSD, NULL) == FALSE) {
@@ -1522,13 +1522,13 @@ copy_file(char *source, char *destination)
 		wchar_t *source_w = utf8_to_utf16(source);
 		if (!source_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, source_w);
-			return -1; /* to avoid the compiler warning */
+			return -1;
 		}
 
 		wchar_t *destination_w = utf8_to_utf16(destination);
 		if (!destination_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, destination_w);
-			return -1; /* to avoid the compiler warning */
+			return -1;
 		}
 
 		if (!CopyFileW(source_w, destination_w, FALSE)) {

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1467,8 +1467,8 @@ is_absolute_path(char *path)
 	return retVal;
 }
 
-/* return 0 - in case of failure */
-BOOL
+/* return -1 - in case of failure, 0 - success */
+int
 create_directory_withsddl(char *path, char *sddl)
 {
 	struct stat st;
@@ -1482,36 +1482,36 @@ create_directory_withsddl(char *path, char *sddl)
 		wchar_t *path_w = utf8_to_utf16(path);
 		if (!path_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, path);
-			return 0; /* to avoid the compiler warning */
+			return -1; /* to avoid the compiler warning */
 		}
 
 		wchar_t *sddl_w = utf8_to_utf16(sddl);
 		if (!sddl_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, sddl);
-			return 0; /* to avoid the compiler warning */
+			return -1; /* to avoid the compiler warning */
 		}
 
 		if (ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl_w, SDDL_REVISION, &pSD, NULL) == FALSE) {
 			error("ConvertStringSecurityDescriptorToSecurityDescriptorW failed with error code %d", GetLastError());
-			return 0;
+			return -1;
 		}
 
 		if (IsValidSecurityDescriptor(pSD) == FALSE) {
 			error("IsValidSecurityDescriptor return FALSE");
-			return 0;
+			return -1;
 		}
 
 		sa.lpSecurityDescriptor = pSD;
 		if (!CreateDirectoryW(path_w, &sa)) {
 			error("Failed to create directory:%ls error:%d", path_w, GetLastError());
-			return 0;
+			return -1;
 		}
 	}
 
-	return 1;
+	return 0;
 }
 
-/* return 0 - in case of failure */
+/* return -1 - in case of failure, 0 - success */
 int
 copy_file(char *source, char *destination)
 {
@@ -1522,21 +1522,21 @@ copy_file(char *source, char *destination)
 		wchar_t *source_w = utf8_to_utf16(source);
 		if (!source_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, source_w);
-			return 0; /* to avoid the compiler warning */
+			return -1; /* to avoid the compiler warning */
 		}
 
 		wchar_t *destination_w = utf8_to_utf16(destination);
 		if (!destination_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, destination_w);
-			return 0; /* to avoid the compiler warning */
+			return -1; /* to avoid the compiler warning */
 		}
 
 		if (!CopyFileW(source_w, destination_w, FALSE)) {
 			error("Failed to copy %ls to %ls, error:%d", source_w, destination_w, GetLastError());
-			return 0;
+			return -1;
 		}
 	}
 
-	return 1;
+	return 0;
 }
 

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1468,7 +1468,7 @@ is_absolute_path(char *path)
 }
 
 /* return 0 - in case of failure */
-int
+BOOL
 create_directory_withsddl(char *path, char *sddl)
 {
 	struct stat st;
@@ -1481,13 +1481,13 @@ create_directory_withsddl(char *path, char *sddl)
 
 		wchar_t *path_w = utf8_to_utf16(path);
 		if (!path_w) {
-			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, path);
+			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, path);
 			return 0; /* to avoid the compiler warning */
 		}
 
 		wchar_t *sddl_w = utf8_to_utf16(sddl);
 		if (!sddl_w) {
-			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, sddl);
+			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, sddl);
 			return 0; /* to avoid the compiler warning */
 		}
 
@@ -1515,19 +1515,19 @@ create_directory_withsddl(char *path, char *sddl)
 int
 copy_file(char *source, char *destination)
 {
-	if (!source || !destination) return 1;
+	if (!source || !destination) return 0;
 
 	struct stat st;
 	if ((stat(destination, &st) < 0) || (stat(source, &st) < 0)) {
 		wchar_t *source_w = utf8_to_utf16(source);
 		if (!source_w) {
-			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, source_w);
+			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, source_w);
 			return 0; /* to avoid the compiler warning */
 		}
 
 		wchar_t *destination_w = utf8_to_utf16(destination);
 		if (!destination_w) {
-			fatal("%s utf8_to_utf16() has failed to convert string:%s", __func__, destination_w);
+			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, destination_w);
 			return 0; /* to avoid the compiler warning */
 		}
 

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1518,7 +1518,7 @@ copy_file(char *source, char *destination)
 	if (!source || !destination) return 0;
 
 	struct stat st;
-	if ((stat(destination, &st) < 0) || (stat(source, &st) < 0)) {
+	if ((stat(source, &st) >= 0) && (stat(destination, &st) < 0)) {
 		wchar_t *source_w = utf8_to_utf16(source);
 		if (!source_w) {
 			error("%s utf8_to_utf16() has failed to convert string:%s", __func__, source_w);

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -40,5 +40,5 @@ int get_machine_domain_name(wchar_t *domain, int size);
 char* get_program_data_path();
 HANDLE get_user_token(char* user);
 int load_user_profile(HANDLE user_token, char* user);
-int copy_file(char *source, char *destination);
-int create_directory_withsddl(char *path, char *sddl);
+BOOL copy_file(char *source, char *destination);
+BOOL create_directory_withsddl(char *path, char *sddl);

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -40,3 +40,5 @@ int get_machine_domain_name(wchar_t *domain, int size);
 char* get_program_data_path();
 HANDLE get_user_token(char* user);
 int load_user_profile(HANDLE user_token, char* user);
+int copy_file(char *source, char *destination);
+int create_directory_withsddl(char *path, char *sddl);

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -40,5 +40,5 @@ int get_machine_domain_name(wchar_t *domain, int size);
 char* get_program_data_path();
 HANDLE get_user_token(char* user);
 int load_user_profile(HANDLE user_token, char* user);
-BOOL copy_file(char *source, char *destination);
-BOOL create_directory_withsddl(char *path, char *sddl);
+int copy_file(char *source, char *destination);
+int create_directory_withsddl(char *path, char *sddl);

--- a/contrib/win32/win32compat/wmain_sshd.c
+++ b/contrib/win32/win32compat/wmain_sshd.c
@@ -99,7 +99,7 @@ static VOID WINAPI service_handler(DWORD dwControl)
 
 #define SSH_HOSTKEY_GEN_CMDLINE L"ssh-keygen -A"
 static void 
-prereq_setup()
+generate_host_keys()
 {
 	TOKEN_USER* info = NULL;
 	DWORD info_len = 0, dwError = 0;
@@ -151,6 +151,50 @@ cleanup:
 		free(info);
 }
 
+/*
+* 1) Create %programdata%\ssh - Administrator group(F), system(F), authorized users(RX).
+* 2) Create %programdata%\ssh\logs - Administrator group(F), system(F)
+* 3) copy <binary_location>\sshd_config_default to %programdata%\ssh\sshd_config
+*/
+static void 
+create_prgdata_ssh_folder()
+{
+	/* create ssh cfg folder */
+	char ssh_cfg_dir[PATH_MAX] = { 0, };
+	strcpy_s(ssh_cfg_dir, _countof(ssh_cfg_dir), get_program_data_path());
+	strcat_s(ssh_cfg_dir, _countof(ssh_cfg_dir), "\\ssh");
+	if (!create_directory_withsddl(ssh_cfg_dir, "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;AU)"))
+		fatal("failed to create %s", ssh_cfg_dir);
+
+	/* create logs folder */
+	char logs_dir[PATH_MAX] = { 0, };
+	strcat_s(logs_dir, _countof(logs_dir), ssh_cfg_dir);
+	strcat_s(logs_dir, _countof(logs_dir), "\\logs");
+	if (!create_directory_withsddl(logs_dir, "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"))
+		fatal("failed to create %s", logs_dir);
+
+	/* COPY sshd_config_default to %programData%\openssh\sshd_config */
+	char sshd_config_path[PATH_MAX] = { 0, };
+	strcat_s(sshd_config_path, _countof(sshd_config_path), ssh_cfg_dir);
+	strcat_s(sshd_config_path, _countof(sshd_config_path), "\\sshd_config");
+	struct stat st;
+	if (stat(sshd_config_path, &st) < 0) {
+		char sshd_config_default_path[PATH_MAX] = { 0, };
+		strcat_s(sshd_config_default_path, _countof(sshd_config_default_path), w32_programdir());
+		strcat_s(sshd_config_default_path, _countof(sshd_config_default_path), "\\sshd_config_default");
+
+		if (!copy_file(sshd_config_default_path, sshd_config_path))
+			fatal("Failed to copy %s to %s, error:%d", sshd_config_default_path, sshd_config_path, GetLastError());
+	}
+}
+
+static void
+prereq_setup()
+{	
+	create_prgdata_ssh_folder();
+	generate_host_keys();
+}
+
 int sshd_main(int argc, wchar_t **wargv) {
 	char** argv = NULL;
 	int i, r;
@@ -177,7 +221,7 @@ int wmain(int argc, wchar_t **wargv) {
 	wchar_t* path_utf16;
 	argc_original = argc;
 	wargv_original = wargv;
-
+	
 	/* change current directory to sshd.exe root */
 	if ( (path_utf16 = utf8_to_utf16(w32_programdir())) == NULL) 
 		return -1;

--- a/contrib/win32/win32compat/wmain_sshd.c
+++ b/contrib/win32/win32compat/wmain_sshd.c
@@ -163,14 +163,14 @@ create_prgdata_ssh_folder()
 	char ssh_cfg_dir[PATH_MAX] = { 0, };
 	strcpy_s(ssh_cfg_dir, _countof(ssh_cfg_dir), get_program_data_path());
 	strcat_s(ssh_cfg_dir, _countof(ssh_cfg_dir), "\\ssh");
-	if (!create_directory_withsddl(ssh_cfg_dir, "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;AU)"))
+	if (create_directory_withsddl(ssh_cfg_dir, "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;AU)") < 0)
 		fatal("failed to create %s", ssh_cfg_dir);
 
 	/* create logs folder */
 	char logs_dir[PATH_MAX] = { 0, };
 	strcat_s(logs_dir, _countof(logs_dir), ssh_cfg_dir);
 	strcat_s(logs_dir, _countof(logs_dir), "\\logs");
-	if (!create_directory_withsddl(logs_dir, "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"))
+	if (create_directory_withsddl(logs_dir, "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)") < 0)
 		fatal("failed to create %s", logs_dir);
 
 	/* COPY sshd_config_default to %programData%\openssh\sshd_config */
@@ -183,7 +183,7 @@ create_prgdata_ssh_folder()
 		strcat_s(sshd_config_default_path, _countof(sshd_config_default_path), w32_programdir());
 		strcat_s(sshd_config_default_path, _countof(sshd_config_default_path), "\\sshd_config_default");
 
-		if (!copy_file(sshd_config_default_path, sshd_config_path))
+		if (copy_file(sshd_config_default_path, sshd_config_path) < 0)
 			fatal("Failed to copy %s to %s, error:%d", sshd_config_default_path, sshd_config_path, GetLastError());
 	}
 }


### PR DESCRIPTION
1) When sshd service starts it creates %programData%\ssh, %programData%\ssh\logs folder and it also copies <binary_location>\sshd_config_default to %programData%\ssh\sshd_config.

2) Didn't remove the code in .\install-sshd.ps1 which also has a similar logic because for existing ssh GitHub users they have to first start sshd service to create %programData%\ssh folder, stop sshd service, copy user's own sshd_config, hostkeys and start the sshd service.