### PR TITLE
test update

### DIFF
--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -162,8 +162,14 @@ WARNING: Following changes will be made to OpenSSH configuration
        New-Item -ItemType Directory -Path $TestDataPath -Force -ErrorAction SilentlyContinue | out-null
     }
 
-    #Backup existing OpenSSH configuration
+    
+    if(-not (Test-Path $OpenSSHConfigPath -pathType Container))
+    {
+        #starting the service will create ssh config folder
+        start-service sshd
+    }    
     $backupConfigPath = Join-Path $OpenSSHConfigPath sshd_config.ori
+    #Backup existing OpenSSH configuration
     if (-not (Test-Path $backupConfigPath -PathType Leaf)) {
         Copy-Item (Join-Path $OpenSSHConfigPath sshd_config) $backupConfigPath -Force
     }

--- a/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
+++ b/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
@@ -58,10 +58,13 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             $authorizedkeyPath = Join-Path $ssouserProfile .testssh\authorized_keys
             $Source = Join-Path $ssouserProfile .ssh\authorized_keys
             $testknownhosts = Join-path $PSScriptRoot testdata\test_known_hosts
-            Copy-Item $Source $ssouserSSHProfilePath -Force -ErrorAction Stop
-
+            Copy-Item $Source $ssouserSSHProfilePath -Force -ErrorAction Stop            
             Repair-AuthorizedKeyPermission -Filepath $authorizedkeyPath -confirm:$false
-            
+            if(-not $skip)
+            {
+                Stop-SSHDTestDaemon
+            }
+                        
             #add wrong password so ssh does not prompt password if failed with authorized keys
             Add-PasswordSetting -Pass "WrongPass"
             $tI=1
@@ -81,8 +84,12 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         }
 
         BeforeEach {
-            $filePath = Join-Path $testDir "$tC.$tI.$fileName"            
-            $logPath = Join-Path $testDir "$tC.$tI.$logName"            
+            $filePath = Join-Path $testDir "$tC.$tI.$fileName"
+            $logPath = Join-Path $testDir "$tC.$tI.$logName"
+            if(-not $skip)
+            {
+                Stop-SSHDTestDaemon
+            }
         }       
 
         It "$tC.$tI-authorized_keys-positive(pwd user is the owner and running process can access to the file)" -skip:$skip {

--- a/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
+++ b/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         $PwdUser = $OpenSSHTestInfo["PasswdUser"]
         $ssouserProfile = $OpenSSHTestInfo["SSOUserProfile"]
         $opensshbinpath = $OpenSSHTestInfo['OpenSSHBinPath']
-        Remove-Item -Path (Join-Path $testDir "*$fileName") -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path (Join-Path $testDir "*$fileName") -Force -ErrorAction SilentlyContinue        
         $platform = Get-Platform
         $skip = ($platform -eq [PlatformType]::Windows) -and ($PSVersionTable.PSVersion.Major -le 2)
         if(($platform -eq [PlatformType]::Windows) -and ($psversiontable.BuildVersion.Major -le 6))
@@ -87,7 +87,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             Get-Process -Name sshd -ErrorAction SilentlyContinue | Where-Object {$_.SessionID -ne 0} | Stop-process -force -ErrorAction SilentlyContinue
         }       
 
-        It "$tC.$tI-authorized_keys-positive(pwd user is the owner and running process can access to the file)" {
+        It "$tC.$tI-authorized_keys-positive(pwd user is the owner and running process can access to the file)" -skip:$skip {
             #setup to have ssouser as owner and grant ssouser read and write, admins group, and local system full control            
             Repair-FilePermission -Filepath $authorizedkeyPath -Owners $objUserSid -FullAccessNeeded  $adminsSid,$systemSid,$objUserSid -confirm:$false
 
@@ -99,7 +99,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             
         }
 
-        It "$tC.$tI-authorized_keys-positive(authorized_keys is owned by local system)" {
+        It "$tC.$tI-authorized_keys-positive(authorized_keys is owned by local system)"  -skip:$skip {
             #setup to have system as owner and grant it full control            
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $systemSid -FullAccessNeeded  $adminsSid,$systemSid,$objUserSid -confirm:$false
 
@@ -112,7 +112,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             
         }
 
-        It "$tC.$tI-authorized_keys-positive(authorized_keys is owned by admins group and pwd does not have explict ACE)" {
+        It "$tC.$tI-authorized_keys-positive(authorized_keys is owned by admins group and pwd does not have explict ACE)"  -skip:$skip {
             #setup to have admin group as owner and grant it full control            
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $adminsSid -FullAccessNeeded $adminsSid,$systemSid -confirm:$false
 
@@ -124,7 +124,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             
         }
 
-        It "$tC.$tI-authorized_keys-positive(authorized_keys is owned by admins group and pwd have explict ACE)" {
+        It "$tC.$tI-authorized_keys-positive(authorized_keys is owned by admins group and pwd have explict ACE)"  -skip:$skip {
             #setup to have admin group as owner and grant it full control
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $adminsSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
 
@@ -136,7 +136,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             
         }
 
-        It "$tC.$tI-authorized_keys-negative(authorized_keys is owned by other admin user)" {
+        It "$tC.$tI-authorized_keys-negative(authorized_keys is owned by other admin user)"  -skip:$skip {
             #setup to have current user (admin user) as owner and grant it full control
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $currentUserSid -FullAccessNeeded $adminsSid,$systemSid -confirm:$false
 
@@ -148,7 +148,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             $logPath | Should Contain "Authentication refused."
         }
 
-        It "$tC.$tI-authorized_keys-negative(other account can access private key file)" {
+        It "$tC.$tI-authorized_keys-negative(other account can access private key file)"  -skip:$skip {
             #setup to have current user as owner and grant it full control            
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
 
@@ -164,7 +164,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             $logPath | Should Contain "Authentication refused."
         }
 
-        It "$tC.$tI-authorized_keys-negative(authorized_keys is owned by other non-admin user)" {
+        It "$tC.$tI-authorized_keys-negative(authorized_keys is owned by other non-admin user)"  -skip:$skip {
             #setup to have PwdUser as owner and grant it full control            
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objPwdUserSid -FullAccessNeeded $adminsSid,$systemSid,$objPwdUser -confirm:$false

--- a/regress/pesterTests/CommonUtils.psm1
+++ b/regress/pesterTests/CommonUtils.psm1
@@ -126,7 +126,7 @@ function Start-SSHDTestDaemon
     {
         start-sleep 1
         $num++
-        if($num -gt 20) { break }
+        if($num -gt 30) { break }
     }
 }
 
@@ -151,6 +151,6 @@ function Stop-SSHDTestDaemon
         # sshd process is still running; wait 1 more seconds"
         start-sleep 1
         $num++
-        if($num -gt 20) { break }
+        if($num -gt 30) { break }
     }
 }

--- a/regress/pesterTests/SSHDConfig.tests.ps1
+++ b/regress/pesterTests/SSHDConfig.tests.ps1
@@ -16,12 +16,12 @@ Describe "Tests of sshd_config" -Tags "CI" {
             $null = New-Item $testDir -ItemType directory -Force -ErrorAction SilentlyContinue
         }        
 
-        $fileName = "test.txt"
-        $logName = "sshdlog.txt"
+        $sshLogName = "test.txt"
+        $sshdLogName = "sshdlog.txt"
         $server = $OpenSSHTestInfo["Target"]
         $opensshbinpath = $OpenSSHTestInfo['OpenSSHBinPath']
         $port = 47003        
-        Remove-Item -Path (Join-Path $testDir "*$fileName") -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path (Join-Path $testDir "*$sshLogName") -Force -ErrorAction SilentlyContinue
 
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
         $ContextName = $env:COMPUTERNAME
@@ -175,8 +175,8 @@ Describe "Tests of sshd_config" -Tags "CI" {
         }
         
         BeforeEach {
-            $filePath = Join-Path $testDir "$tC.$tI.$fileName"            
-            $logPath = Join-Path $testDir "$tC.$tI.$logName"
+            $sshlog = Join-Path $testDir "$tC.$tI.$sshLogName"            
+            $sshdlog = Join-Path $testDir "$tC.$tI.$sshdLogName"
             if(-not $skip)
             {
                 Stop-SSHDTestDaemon
@@ -190,7 +190,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User with full name in the list of AllowUsers"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $allowUser1 -Password $password -GroupName $allowGroup1
 
@@ -203,7 +203,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User with * wildcard"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $allowUser2 -Password $password -GroupName $allowGroup1
            
@@ -216,7 +216,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User with ? wildcard"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
            Add-UserToLocalGroup -UserName $allowUser3 -Password $password -GroupName $allowGroup1
            
            $o = ssh  -p $port $allowUser3@$server -o "UserKnownHostsFile $testknownhosts" echo 1234
@@ -228,27 +228,27 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User with full name in the list of AllowUsers but not in any AllowGroups"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-LocalUser -UserName $allowUser4 -Password $password
 
-           ssh -p $port -E $filePath -o "UserKnownHostsFile $testknownhosts" $allowUser4@$server echo 1234
+           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $allowUser4@$server echo 1234
            $LASTEXITCODE | Should Not Be 0
            Stop-SSHDTestDaemon
-           $logPath | Should Contain "not allowed because not in any group"
+           $sshdlog | Should Contain "not allowed because not in any group"
            
         }
 
         It "$tC.$tI-User with full name in the list of DenyUsers"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $denyUser1 -Password $password -GroupName $allowGroup1
 
-           ssh -p $port -E $filePath -o "UserKnownHostsFile $testknownhosts" $denyUser1@$server echo 1234
+           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $denyUser1@$server echo 1234
            $LASTEXITCODE | Should Not Be 0
            Stop-SSHDTestDaemon
-           $logPath | Should Contain "not allowed because listed in DenyUsers"
+           $sshdlog | Should Contain "not allowed because listed in DenyUsers"
 
            Remove-UserFromLocalGroup -UserName $denyUser1 -GroupName $allowGroup1
 
@@ -256,14 +256,14 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User with * wildcard in the list of DenyUsers"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $denyUser2 -Password $password -GroupName $allowGroup1
 
-           ssh -p $port -E $filePath -o "UserKnownHostsFile $testknownhosts" $denyUser2@$server echo 1234
+           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $denyUser2@$server echo 1234
            $LASTEXITCODE | Should Not Be 0
            Stop-SSHDTestDaemon
-           $logPath | Should Contain "not allowed because listed in DenyUsers"
+           $sshdlog | Should Contain "not allowed because listed in DenyUsers"
 
            Remove-UserFromLocalGroup -UserName $denyUser2 -GroupName $allowGroup1
 
@@ -271,14 +271,14 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User with ? wildcard in the list of DenyUsers"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $denyUser3 -Password $password -GroupName $allowGroup1
 
-           ssh -p $port -E $filePath -o "UserKnownHostsFile $testknownhosts" $denyUser3@$server echo 1234
+           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $denyUser3@$server echo 1234
            $LASTEXITCODE | Should Not Be 0
            Stop-SSHDTestDaemon
-           $logPath | Should Contain "not allowed because not listed in AllowUsers"
+           $sshdlog | Should Contain "not allowed because not listed in AllowUsers"
            
            Remove-UserFromLocalGroup -UserName $denyUser3 -GroupName $allowGroup1
 
@@ -286,15 +286,15 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User is listed in the list of AllowUsers but also in a full name DenyGroups and AllowGroups"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $localuser1 -Password $password -GroupName $allowGroup1
            Add-UserToLocalGroup -UserName $localuser1 -Password $password -GroupName $denyGroup1
            
-           ssh -p $port -E $filePath -o "UserKnownHostsFile $testknownhosts" $localuser1@$server echo 1234
+           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $localuser1@$server echo 1234
            $LASTEXITCODE | Should Not Be 0
            Stop-SSHDTestDaemon
-           $logPath | Should Contain "not allowed because a group is listed in DenyGroups"
+           $sshdlog | Should Contain "not allowed because a group is listed in DenyGroups"
 
            Remove-UserFromLocalGroup -UserName $localuser1 -GroupName $allowGroup1
            Remove-UserFromLocalGroup -UserName $localuser1 -GroupName $denyGroup1
@@ -303,14 +303,14 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User is listed in the list of AllowUsers but also in a wildcard * DenyGroups"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $localuser2 -Password $password -GroupName $denyGroup2
            
-           ssh -p $port -E $filePath -o "UserKnownHostsFile $testknownhosts" $localuser2@$server echo 1234
+           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $localuser2@$server echo 1234
            $LASTEXITCODE | Should Not Be 0
            Stop-SSHDTestDaemon
-           $logPath | Should Contain "not allowed because a group is listed in DenyGroups"
+           $sshdlog | Should Contain "not allowed because a group is listed in DenyGroups"
            
            Remove-UserFromLocalGroup -UserName $localuser2 -GroupName $denyGroup2
 
@@ -318,14 +318,14 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         It "$tC.$tI-User is listed in the list of AllowUsers but also in a wildcard ? DenyGroups"  -skip:$skip {
            #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
+           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
 
            Add-UserToLocalGroup -UserName $localuser3 -Password $password -GroupName $denyGroup3
            
-           ssh -p $port -E $filePath -o "UserKnownHostsFile $testknownhosts" $localuser3@$server echo 1234
+           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $localuser3@$server echo 1234
            $LASTEXITCODE | Should Not Be 0
            Stop-SSHDTestDaemon
-           $logPath | Should Contain "not allowed because a group is listed in DenyGroups"
+           $sshdlog | Should Contain "not allowed because a group is listed in DenyGroups"
            
            Remove-UserFromLocalGroup -UserName $localuser3 -GroupName $denyGroup3
 

--- a/regress/pesterTests/SSHDConfig.tests.ps1
+++ b/regress/pesterTests/SSHDConfig.tests.ps1
@@ -113,7 +113,11 @@ Describe "Tests of sshd_config" -Tags "CI" {
             }
         }
         $platform = Get-Platform
-        $skip = ($platform -eq [PlatformType]::Windows) -and ($PSVersionTable.PSVersion.Major -le 2)        
+        $skip = ($platform -eq [PlatformType]::Windows) -and ($PSVersionTable.PSVersion.Major -le 2)
+        if(-not $skip)
+        {
+            Stop-SSHDTestDaemon
+        }
         if(($platform -eq [PlatformType]::Windows) -and ($psversiontable.BuildVersion.Major -le 6))
         {
             #suppress the firewall blocking dialogue on win7
@@ -173,6 +177,10 @@ Describe "Tests of sshd_config" -Tags "CI" {
         BeforeEach {
             $filePath = Join-Path $testDir "$tC.$tI.$fileName"            
             $logPath = Join-Path $testDir "$tC.$tI.$logName"
+            if(-not $skip)
+            {
+                Stop-SSHDTestDaemon
+            }
         }
 
         AfterAll {            

--- a/regress/pesterTests/SSHDConfig.tests.ps1
+++ b/regress/pesterTests/SSHDConfig.tests.ps1
@@ -14,7 +14,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
         if( -not (Test-path $testDir -PathType Container))
         {
             $null = New-Item $testDir -ItemType directory -Force -ErrorAction SilentlyContinue
-        }
+        }        
 
         $fileName = "test.txt"
         $logName = "sshdlog.txt"
@@ -113,7 +113,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
             }
         }
         $platform = Get-Platform
-        $skip = ($platform -eq [PlatformType]::Windows) -and ($PSVersionTable.PSVersion.Major -le 2)
+        $skip = ($platform -eq [PlatformType]::Windows) -and ($PSVersionTable.PSVersion.Major -le 2)        
         if(($platform -eq [PlatformType]::Windows) -and ($psversiontable.BuildVersion.Major -le 6))
         {
             #suppress the firewall blocking dialogue on win7
@@ -123,7 +123,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
     AfterEach { $tI++ }
     
-    AfterAll {
+    AfterAll {        
         $PrincipalContext.Dispose()
         if(($platform -eq [PlatformType]::Windows) -and ($psversiontable.BuildVersion.Major -le 6))
         {            
@@ -180,7 +180,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
             $tC++
         }
 
-        It "$tC.$tI-User with full name in the list of AllowUsers" {
+        It "$tC.$tI-User with full name in the list of AllowUsers"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -193,7 +193,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User with * wildcard" {
+        It "$tC.$tI-User with * wildcard"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -206,7 +206,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User with ? wildcard" {
+        It "$tC.$tI-User with ? wildcard"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
            Add-UserToLocalGroup -UserName $allowUser3 -Password $password -GroupName $allowGroup1
@@ -218,7 +218,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User with full name in the list of AllowUsers but not in any AllowGroups" {
+        It "$tC.$tI-User with full name in the list of AllowUsers but not in any AllowGroups"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -231,7 +231,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
            
         }
 
-        It "$tC.$tI-User with full name in the list of DenyUsers" {
+        It "$tC.$tI-User with full name in the list of DenyUsers"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -246,7 +246,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User with * wildcard in the list of DenyUsers" {
+        It "$tC.$tI-User with * wildcard in the list of DenyUsers"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -261,7 +261,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User with ? wildcard in the list of DenyUsers" {
+        It "$tC.$tI-User with ? wildcard in the list of DenyUsers"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -276,7 +276,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User is listed in the list of AllowUsers but also in a full name DenyGroups and AllowGroups" {
+        It "$tC.$tI-User is listed in the list of AllowUsers but also in a full name DenyGroups and AllowGroups"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -293,7 +293,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User is listed in the list of AllowUsers but also in a wildcard * DenyGroups" {
+        It "$tC.$tI-User is listed in the list of AllowUsers but also in a wildcard * DenyGroups"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 
@@ -308,7 +308,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User is listed in the list of AllowUsers but also in a wildcard ? DenyGroups" {
+        It "$tC.$tI-User is listed in the list of AllowUsers but also in a wildcard ? DenyGroups"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $logPath" 
 


### PR DESCRIPTION
1. Move Start-SSHD-TestDaemon and Stop-SSHD-TestDaemon to commonUtils.psm1
2. fix the timing issue when trying to read the log while it is still locked by the process.
3. start the service to create the config fold if it is not there.
4. skip authorizedkey and sshdconfig tests on win7 since the task scheduler cmdlets are not available on win7.