### PR TITLE
Allow remote session processes to break away from session job object

### DIFF
--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -1790,7 +1790,7 @@ wmain(int ac, wchar_t **av)
 	}
 
 	memset(&job_info, 0, sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
-	job_info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+	job_info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
 
 	if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &job_info, sizeof(job_info)) ||
 		!AssignProcessToJobObject(job, GetCurrentProcess())) {


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/1032

Issue: Ssh-shellhost.exe creates a job object and ties all its child processes to its lifetime. It does not allow the child processes to break away from this job. This restriction is unnecessary. 

Fix: Modified job object to allow child processes to break away if they need to.