### PR TITLE
fix .\sshd.exe -d

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1460,6 +1460,9 @@ int
 is_absolute_path(char *path)
 {
 	int retVal = 0;
+	if(*path == '\"') /* skip double quote if path is "c:\abc" */
+		path++;
+
 	if (*path == '/' || *path == '\\' || (*path != '\0' && isalpha(*path) && path[1] == ':') ||
 	    ((strlen(path) >= strlen(PROGRAM_DATA)) && (memcmp(path, PROGRAM_DATA, strlen(PROGRAM_DATA)) == 0)))
 		retVal = 1;

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1466,7 +1466,7 @@ is_absolute_path(char *path)
 	if (*path == '/' || *path == '\\' || (*path != '\0' && isalpha(*path) && path[1] == ':') ||
 	    ((strlen(path) >= strlen(PROGRAM_DATA)) && (memcmp(path, PROGRAM_DATA, strlen(PROGRAM_DATA)) == 0)))
 		retVal = 1;
-	
+
 	return retVal;
 }
 

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -951,7 +951,7 @@ spawn_child_internal(char* cmd, char *const argv[], HANDLE in, HANDLE out, HANDL
 	char * const *t1;
 	DWORD cmdline_len = 0;
 	wchar_t * cmdline_utf16 = NULL;
-	int add_module_path = 0, ret = -1;		
+	int add_module_path = 0, ret = -1;
 
 	/* should module path be added */
 	if (!cmd) {

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -37,6 +37,7 @@
 #include "inc\fcntl.h"
 #include "inc\sys\un.h"
 #include "inc\utf.h"
+#include "inc\stdio.h"
 
 #include "w32fd.h"
 #include "signal_internal.h"
@@ -950,19 +951,17 @@ spawn_child_internal(char* cmd, char *const argv[], HANDLE in, HANDLE out, HANDL
 	char * const *t1;
 	DWORD cmdline_len = 0;
 	wchar_t * cmdline_utf16 = NULL;
-	int add_module_path = 0, ret = -1;
+	int add_module_path = 0, ret = -1;		
 
 	/* should module path be added */
-	do {
-		if (!cmd)
-			break;
-		t = cmd;
-		if (*t == '\"')
-			t++;
-		if (t[0] == '\0' || t[0] == '\\' || t[0] == '.' || t[1] == ':')
-			break;
+	if (!cmd) {
+		error("%s invalid argument cmd:%s", __func__, cmd);
+		return -1;
+	}
+
+	t = cmd;
+	if (!is_absolute_path(t))
 		add_module_path = 1;
-	} while (0);
 
 	/* compute total cmdline len*/
 	if (add_module_path)


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/1045

Create process fails if we directly pass ".\ssh.exe -d".
We need to append the full binary path to CreateProces().