### PR TITLE
Multiple Fixes

### DIFF
--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -111,6 +111,8 @@ get_passwd(const char *user_utf8, LPWSTR user_sid)
 	int tmp_len = PATH_MAX;
 	PDOMAIN_CONTROLLER_INFOW pdc = NULL;
 	DWORD dsStatus, uname_upn_len = 0, uname_len = 0, udom_len = 0;
+	wchar_t wmachine_name[MAX_COMPUTERNAME_LENGTH + 1];
+	DWORD wmachine_name_len = MAX_COMPUTERNAME_LENGTH + 1;
 	errno_t r = 0;
 
 	errno = 0;
@@ -133,6 +135,14 @@ get_passwd(const char *user_utf8, LPWSTR user_sid)
 	} else {
 		uname_utf16 = user_utf16;
 		udom_utf16 = NULL;
+	}
+
+	if (udom_utf16) {
+		/* this should never fail */
+		GetComputerNameW(wmachine_name, &wmachine_name_len);
+		/* If this is a local account (domain part and computer name are the same), strip out domain */
+		if (_wcsicmp(udom_utf16, wmachine_name) == 0)
+			udom_utf16 = L'\0';
 	}
 
 	if (user_sid == NULL) {

--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -142,7 +142,7 @@ get_passwd(const char *user_utf8, LPWSTR user_sid)
 		GetComputerNameW(wmachine_name, &wmachine_name_len);
 		/* If this is a local account (domain part and computer name are the same), strip out domain */
 		if (_wcsicmp(udom_utf16, wmachine_name) == 0)
-			udom_utf16 = L'\0';
+			udom_utf16 = NULL;
 	}
 
 	if (user_sid == NULL) {

--- a/regress/pesterTests/SSHDConfig.tests.ps1
+++ b/regress/pesterTests/SSHDConfig.tests.ps1
@@ -337,7 +337,7 @@ Describe "Tests of sshd_config" -Tags "CI" {
             Add-LocalUser -UserName $matchuser -Password $password
             Add-UserToLocalGroup -UserName $matchuser  -Password $password -GroupName $ $allowGroup1
 
-            $o = ssh  -p $port -T $matchuser@$server randomcommand
+            $o = ssh  -p $port -T -o "UserKnownHostsFile $testknownhosts" $matchuser@$server randomcommand
             # Match block's ForceCommand returns output of "whoami & set SSH_ORIGINAL_COMMAND"
             $o[0].Contains($matchuser) | Should Be $true
             $o[1].Contains("randomcommand") | Should Be $true

--- a/regress/pesterTests/SSHDConfig.tests.ps1
+++ b/regress/pesterTests/SSHDConfig.tests.ps1
@@ -330,6 +330,20 @@ Describe "Tests of sshd_config" -Tags "CI" {
            Remove-UserFromLocalGroup -UserName $localuser3 -GroupName $denyGroup3
 
         }
+
+        It "$tC.$tI - Match User block with ForceCommand" -skip:$skip  {
+            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
+            $matchuser = "matchuser"
+            Add-LocalUser -UserName $matchuser -Password $password
+            Add-UserToLocalGroup -UserName $matchuser  -Password $password -GroupName $ $allowGroup1
+
+            $o = ssh  -p $port -T $matchuser@$server randomcommand
+            # Match block's ForceCommand returns output of "whoami & set SSH_ORIGINAL_COMMAND"
+            $o[0].Contains($matchuser) | Should Be $true
+            $o[1].Contains("randomcommand") | Should Be $true
+            Stop-SSHDTestDaemon
+            Remove-LocalUser -Name $matchuser
+        }
 #>
     }
 }

--- a/regress/pesterTests/SSHDConfig.tests.ps1
+++ b/regress/pesterTests/SSHDConfig.tests.ps1
@@ -334,15 +334,15 @@ Describe "Tests of sshd_config" -Tags "CI" {
         It "$tC.$tI - Match User block with ForceCommand" -skip:$skip  {
             Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
             $matchuser = "matchuser"
-            Add-LocalUser -UserName $matchuser -Password $password
-            Add-UserToLocalGroup -UserName $matchuser  -Password $password -GroupName $ $allowGroup1
+            Add-UserToLocalGroup -UserName $matchuser -Password $password -GroupName $allowGroup1
 
             $o = ssh  -p $port -T -o "UserKnownHostsFile $testknownhosts" $matchuser@$server randomcommand
             # Match block's ForceCommand returns output of "whoami & set SSH_ORIGINAL_COMMAND"
             $o[0].Contains($matchuser) | Should Be $true
             $o[1].Contains("randomcommand") | Should Be $true
+            
             Stop-SSHDTestDaemon
-            Remove-LocalUser -Name $matchuser
+            Remove-UserFromLocalGroup -UserName $matchuser -GroupName $allowGroup1
         }
 #>
     }

--- a/regress/pesterTests/testdata/SSHD_Config
+++ b/regress/pesterTests/testdata/SSHD_Config
@@ -113,6 +113,9 @@ Subsystem	sftp	sftp-server.exe -l DEBUG3
 PubkeyAcceptedKeyTypes ssh-ed25519*
 
 DenyUsers denyuser1 deny*2 denyuse?3, 
-AllowUsers allowuser1 allowu*r2 allow?se?3 allowuser4 localuser1 localu*r2 loc?lu?er3 localadmin
+AllowUsers allowuser1 allowu*r2 allow?se?3 allowuser4 localuser1 localu*r2 loc?lu?er3 localadmin matchuser
 DenyGroups denygroup1 denygr*p2 deny?rou?3
 AllowGroups allowgroup1 allowg*2 allowg?ou?3 Adm*
+
+Match User matchuser
+	ForceCommand cmd.exe /c "whoami & set SSH_ORIGINAL_COMMAND"

--- a/sshd.c
+++ b/sshd.c
@@ -742,7 +742,9 @@ privsep_preauth(Authctxt *authctxt)
 
 #ifdef FORK_NOT_SUPPORTED
 	if (privsep_auth_child) {
-		authctxt->pw = w32_getpwuid(1);
+		struct passwd* me = getpwuid(geteuid());
+		/* this re-does the user specific config */
+		authctxt->pw = getpwnamallow(xstrdup(me->pw_name));
 		authctxt->valid = 1;
 		return 1;
 	}


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/1065
Fix: In recent sshd architectural changes, post authentication changes that process user specific changes were missing in authenticated sshd worker. Added missing call.

https://github.com/PowerShell/Win32-OpenSSH/issues/1052
Fix: getpwd* functions will now strip off domain of any local user account. 
