### PR TITLE
Bandwidth limits don't work correctly for sftp client

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -67,8 +67,9 @@ static char* s_programdir = NULL;
 #define REPARSE_MOUNTPOINT_HEADER_SIZE 8
 
  /* Difference in us between UNIX Epoch and Win32 Epoch */
-#define EPOCH_DELTA_US  116444736000000000ULL
+#define EPOCH_DELTA  116444736000000000ULL /* in 100 nsecs intervals */
 #define RATE_DIFF 10000000ULL /* 100 nsecs */
+
 #define NSEC_IN_SEC 1000000000ULL // 10**9
 #define USEC_IN_SEC 1000000ULL // 10**6
 
@@ -214,7 +215,7 @@ gettimeofday(struct timeval *tv, void *tz)
 	GetSystemTimeAsFileTime(&timehelper.ft);	
 
 	/* Remove the epoch difference & convert 100ns to us */
-	us = (timehelper.ns - EPOCH_DELTA_US) / 10;
+	us = (timehelper.ns - EPOCH_DELTA) / 10;
 
 	/* Stuff result into the timeval */
 	tv->tv_sec = (long)(us / USEC_IN_SEC);
@@ -556,7 +557,7 @@ void
 unix_time_to_file_time(ULONG t, LPFILETIME pft)
 {
 	ULONGLONG ull;
-	ull = UInt32x32To64(t, RATE_DIFF) + EPOCH_DELTA_US;
+	ull = UInt32x32To64(t, RATE_DIFF) + EPOCH_DELTA;
 
 	pft->dwLowDateTime = (DWORD)ull;
 	pft->dwHighDateTime = (DWORD)(ull >> 32);
@@ -567,7 +568,7 @@ void
 file_time_to_unix_time(const LPFILETIME pft, time_t * winTime)
 {
 	*winTime = ((long long)pft->dwHighDateTime << 32) + pft->dwLowDateTime;
-	*winTime -= EPOCH_DELTA_US;
+	*winTime -= EPOCH_DELTA;
 	*winTime /= RATE_DIFF;		 /* Nano to seconds resolution */
 }
 


### PR DESCRIPTION
How to reproduce
Just try to use "-l" option and upload/download a big file by sftp.exe and you will see that limit isn't correct. e.g. "sftp -l 1000 u@localhost" and try to download 5МB file. It means 1000 kilobits per second limitation on bandwidth but you will see ~30 kiloBYTES per second. 
"30 * 1024 * 8" bps != "1000 * 1000" bps

There are several bugs in gettimeofday and nanosleep functions:
gettimeofday
- Incorrect converting 100ns intervals (from GetSystemTimeAsFileTime) to timeval.
(us % RATE_DIFF) means number of microseconds but it may be great than 10**6

nanosleep
- SetWaitableTimer works with 100ns intervals but get nanoseconnds (only part of timespec)
- Missed CloseHandle call in WaitForSingleObject error case.

https://github.com/PowerShell/Win32-OpenSSH/issues/1094
