### PR TITLE
Fixed regression caused due to ETW support changes

### DIFF
--- a/contrib/win32/openssh/AppveyorHelper.psm1
+++ b/contrib/win32/openssh/AppveyorHelper.psm1
@@ -167,10 +167,7 @@ function Install-OpenSSH
 
     Push-Location $OpenSSHDir 
     & "$OpenSSHDir\install-sshd.ps1"
-    & "$OpenSSHDir\ssh-keygen.exe" -A    
-    & "$OpenSSHDir\FixHostFilePermissions.ps1" -Confirm:$false
 
-    #machine will be reboot after Install-openssh anyway
     $machinePath = [Environment]::GetEnvironmentVariable('Path', 'MACHINE')
     $newMachineEnvironmentPath = $machinePath
     if (-not ($machinePath.ToLower().Contains($OpenSSHDir.ToLower())))
@@ -184,8 +181,8 @@ function Install-OpenSSH
         [Environment]::SetEnvironmentVariable('Path', $newMachineEnvironmentPath, 'MACHINE')
     }
     
-    Set-Service sshd -StartupType Automatic 
-    Set-Service ssh-agent -StartupType Automatic
+    Start-Service -Name sshd 
+    Start-Service -Name ssh-agent
 
     Pop-Location
     Write-BuildMessage -Message "OpenSSH installed!" -Category Information

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -84,7 +84,7 @@ function Set-OpenSSHTestEnvironment
         "NoLibreSSL" = $Script:NoLibreSSL
         }
 
-    #start service
+    #start service if not already started
     Start-Service -Name sshd
         
     #if user does not set path, pick it up
@@ -165,12 +165,6 @@ WARNING: Following changes will be made to OpenSSH configuration
        New-Item -ItemType Directory -Path $TestDataPath -Force -ErrorAction SilentlyContinue | out-null
     }
 
-    
-    if(-not (Test-Path $OpenSSHConfigPath -pathType Container))
-    {
-        #starting the service will create ssh config folder
-        start-service sshd
-    }    
     $backupConfigPath = Join-Path $OpenSSHConfigPath sshd_config.ori
     #Backup existing OpenSSH configuration
     if (-not (Test-Path $backupConfigPath -PathType Leaf)) {

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -83,6 +83,9 @@ function Set-OpenSSHTestEnvironment
         "PostmortemDebugging" = $Script:PostmortemDebugging
         "NoLibreSSL" = $Script:NoLibreSSL
         }
+
+    #start service
+    Start-Service -Name sshd
         
     #if user does not set path, pick it up
     if([string]::IsNullOrEmpty($OpenSSHBinPath))

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -8,8 +8,6 @@ $scriptdir = Split-Path $scriptpath
 
 $sshdpath = Join-Path $scriptdir "sshd.exe"
 $sshagentpath = Join-Path $scriptdir "ssh-agent.exe"
-$sshdir = Join-Path $env:ProgramData "\ssh"
-$logsdir = Join-Path $sshdir "logs"
 $etwman = Join-Path $scriptdir "openssh-events.man"
 
 if (-not (Test-Path $sshdpath)) {
@@ -44,41 +42,5 @@ New-Service -Name ssh-agent -BinaryPathName `"$sshagentpath`" -Description "SSH 
 cmd.exe /c 'sc.exe sdset ssh-agent D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RP;;;AU)'
 
 New-Service -Name sshd -BinaryPathName `"$sshdpath`" -Description "SSH Daemon" -StartupType Manual | Out-Null
-
-#create the ssh config folder and set its permissions
-if(-not (test-path $sshdir -PathType Container))
-{
-    $null = New-Item $sshdir -ItemType Directory -Force -ErrorAction Stop
-}
-$acl = Get-Acl -Path $sshdir
-# following SDDL implies 
-# - owner - built in Administrators
-# - disabled inheritance
-# - Full access to System
-# - Full access to built in Administrators
-$acl.SetSecurityDescriptorSddlForm("O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;AU)")
-Set-Acl -Path $sshdir -AclObject $acl
-
-# create logs folder and set its permissions
-if(-not (test-path $logsdir -PathType Container))
-{
-    $null = New-Item $logsdir -ItemType Directory -Force -ErrorAction Stop
-}
-$acl = Get-Acl -Path $logsdir
-# following SDDL implies 
-# - owner - built in Administrators
-# - disabled inheritance
-# - Full access to System
-# - Full access to built in Administrators
-$acl.SetSecurityDescriptorSddlForm("O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
-Set-Acl -Path $logsdir -AclObject $acl
-
-#copy sshd_config_default to $sshdir\sshd_config
-$sshdconfigpath = Join-Path $sshdir "sshd_config"
-$sshddefaultconfigpath = Join-Path $scriptdir "sshd_config_default"
-if(-not (test-path $sshdconfigpath -PathType Leaf))
-{
-    $null = Copy-Item $sshddefaultconfigpath -Destination $sshdconfigpath  -ErrorAction Stop
-}
 
 Write-Host -ForegroundColor Green "sshd and ssh-agent services successfully installed"

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -54,7 +54,9 @@
 #include "inc\string.h"
 #include "inc\grp.h"
 
-/* Maximum reparse buffer info size. The max user defined reparse 
+static char* s_programdir = NULL;
+
+/* Maximum reparse buffer info size. The max user defined reparse
  * data is 16KB, plus there's a header. 
  */
 #define MAX_REPARSE_SIZE 17000 
@@ -400,6 +402,34 @@ w32_setvbuf(FILE *stream, char *buffer, int mode, size_t size) {
 		return setvbuf(stream, NULL, _IONBF, 0);
 	else
 		return setvbuf(stream, buffer, mode, size);
+}
+
+/* TODO - deprecate this. This is not a POSIX API, used internally only */
+char *
+w32_programdir()
+{
+	wchar_t* wpgmptr;
+
+	if (s_programdir != NULL)
+		return s_programdir;
+
+	if (_get_wpgmptr(&wpgmptr) != 0)
+		return NULL;
+
+	if ((s_programdir = utf16_to_utf8(wpgmptr)) == NULL)
+		return NULL;
+
+	/* null terminate after directory path */
+	char* tail = s_programdir + strlen(s_programdir);
+	while (tail > s_programdir && *tail != '\\' && *tail != '/')
+		tail--;
+
+	if (tail > s_programdir)
+		*tail = '\0';
+	else
+		*tail = '.'; /* current directory */
+
+	return s_programdir;
 }
 
 int

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -71,7 +71,6 @@ void fd_decode_state(char*);
 
 /* __progname */
 char* __progname = "";
-static char* s_programdir = "";
 
 /* initializes mapping table*/
 static int
@@ -161,28 +160,24 @@ fd_table_clear(int index)
 	FD_CLR(index, &(fd_table.occupied));
 }
 
-char *
-w32_programdir()
-{
-	return s_programdir;
-}
-
+/* TODO - consolidate w32_programdir logic in here */
 static int 
 init_prog_paths()
 {
 	wchar_t* wpgmptr;
+	char* pgmptr;
 
 	if (_get_wpgmptr(&wpgmptr) != 0) {
 		errno = EOTHER;
 		return -1;
 	}
 
-	if ((s_programdir = utf16_to_utf8(wpgmptr)) == NULL) {
+	if ((pgmptr = utf16_to_utf8(wpgmptr)) == NULL) {
 		errno = ENOMEM;
 		return -1;
 	}
 
-	__progname = strrchr(s_programdir, '\\') + 1;
+	__progname = strrchr(pgmptr, '\\') + 1;
 	*(__progname - 1) = '\0';
 
 	/* strip .exe off __progname */


### PR DESCRIPTION
Regression: Service is unable to start if "ssh" programdata directory is missing. 

Reason: This is due to refactored changes around w32_programdir() that moved its initialization to within win32_posix_initialize. sshd_main() is relying on this call even before the POSIX layer gets initialized. 

Fix: Reverted the refactoring changes and added comments to consolidate these changes later. Also removed directory creation logic in install-sshd.ps1 that masked this issue before. 