### PR TITLE
 Unit Test Updates / Small Bug Fixes

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -687,6 +687,11 @@ w32_rename(const char *old_name, const char *new_name)
 	char old_name_resolved[PATH_MAX] = {0, };
 	char new_name_resolved[PATH_MAX] = {0, };
 
+	if (old_name == NULL || new_name == NULL) {
+		errno = EFAULT;
+		return -1;
+	}
+
 	strcpy_s(old_name_resolved, _countof(old_name_resolved), resolved_path(old_name));
 	strcpy_s(new_name_resolved, _countof(new_name_resolved), resolved_path(new_name));
 

--- a/contrib/win32/win32compat/socketio.c
+++ b/contrib/win32/win32compat/socketio.c
@@ -195,7 +195,7 @@ socketio_WSARecv(struct w32_io* pio, BOOL* completed, int len)
 		wsabuf.buf = pio->read_details.buf;
 
 	if (len)
-		wsabuf.len = len;
+		wsabuf.len = min(len, wsabuf.len);
 
 	ret = WSARecv(pio->sock, &wsabuf, 1, NULL, &recv_flags, &pio->read_overlapped, &WSARecvCompletionRoutine);
 	if (ret == 0) {

--- a/regress/unittests/win32compat/file_tests.c
+++ b/regress/unittests/win32compat/file_tests.c
@@ -436,10 +436,11 @@ file_miscellaneous_tests()
 	f = open(tmp_filename, O_RDWR | O_CREAT | O_TRUNC, 0600);
 	ASSERT_INT_NE(f, -1);
 	int f1 = dup(f);
-	ASSERT_INT_EQ(f1, -1);
+	ASSERT_INT_NE(f1, -1);
 	HANDLE h = w32_fd_to_handle(f);
 	ASSERT_HANDLE(h);
 	close(f);
+	close(f1);
 
 	char *tmp_filename_1 = "tmp_1.txt";
 	retValue = rename(tmp_filename, tmp_filename_1);


### PR DESCRIPTION
- Updated socketio_WSARecv() to prevent attempted buffer overrun which was causing test case to fail.
- Updated w32_rename() to handle error when input parameters are null which was causing test case to fail.
- Updated file verify success on dup() test.