### PR TITLE
Fix for orphaned unprivileged workers on sshd login timeout

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -776,15 +776,28 @@ privsep_preauth(Authctxt *authctxt)
 		    posix_spawn_file_actions_adddup2(&actions, tmp_sock, STDOUT_FILENO) != 0 ||
 		    posix_spawn_file_actions_adddup2(&actions, pmonitor->m_recvfd, PRIVSEP_MONITOR_FD) != 0 ||
 		    posix_spawn_file_actions_adddup2(&actions, pmonitor->m_log_sendfd, PRIVSEP_LOG_FD) != 0 )
-			error("posix_spawn initialization failed");		
-		else {
+			fatal("posix_spawn initialization failed");		
+		
+		{
 			char** argv = privsep_child_cmdline(0);
 			if (__posix_spawn_asuser(&pid, argv[0], &actions, NULL, argv, NULL, SSH_PRIVSEP_USER) != 0)
-				error("%s, posix_spawn failed", __func__);
-			else
-				debug2("Network child is on pid %ld", (long)pid);
+				fatal("%s, fork of unprivileged child failed", __func__);
+			
 			posix_spawn_file_actions_destroy(&actions);
 		}
+
+		debug2("Network child is on pid %ld", (long)pid);
+
+		pmonitor->m_pid = pid;
+		if (have_agent) {
+			r = ssh_get_authentication_socket(&auth_sock);
+			if (r != 0) {
+				error("Could not get agent socket: %s",
+					ssh_err(r));
+				have_agent = 0;
+			}
+		}
+
 		close(pmonitor->m_recvfd);
 		close(pmonitor->m_log_sendfd);
 		send_config_state(pmonitor->m_sendfd, &cfg);
@@ -884,16 +897,16 @@ privsep_postauth(Authctxt *authctxt)
 		    posix_spawn_file_actions_adddup2(&actions, tmp_sock, STDIN_FILENO) != 0 ||
 		    posix_spawn_file_actions_adddup2(&actions, tmp_sock, STDOUT_FILENO) != 0 ||
 		    posix_spawn_file_actions_adddup2(&actions, pmonitor->m_recvfd, PRIVSEP_MONITOR_FD) != 0)
-			error("posix_spawn initialization failed");
-		else {
+			fatal("posix_spawn initialization failed");
+		
+		{
 			char** argv = privsep_child_cmdline(1);
 			if (__posix_spawn_asuser(&pmonitor->m_pid, argv[0], &actions, NULL, argv, NULL, authctxt->pw->pw_name) != 0)
-				error("%s, posix_spawn failed", __func__);
-			else
-				verbose("User child is on pid %ld", (long)pmonitor->m_pid);
+				fatal("fork of unprivileged child failed");
 			posix_spawn_file_actions_destroy(&actions);
 		}
 		
+		verbose("User child is on pid %ld", (long)pmonitor->m_pid);
 		send_config_state(pmonitor->m_sendfd, &cfg);
 		send_hostkeys_state(pmonitor->m_sendfd);
 		send_idexch_state(pmonitor->m_sendfd);


### PR DESCRIPTION
Issue: When sshd times out due to login grace timeout, it leaves behind the unprivileged worker orphaned.

Fix: Add missing child's reference in monitor. 