### PR TITLE
Fix for orphaned unprivileged workers on sshd login timeout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ image: Visual Studio 2015
 branches:
   only:
     - latestw_all
+    - hotfix
 
 init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/contrib/win32/openssh/version.rc
+++ b/contrib/win32/openssh/version.rc
@@ -17,6 +17,7 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -50,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 7,6,0,0
- PRODUCTVERSION 7,6,0,0
+ FILEVERSION 7,6,0,1
+ PRODUCTVERSION 7,6,0,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -66,7 +67,7 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "FileVersion", "7.6.0.0"
+            VALUE "FileVersion", "7.6.0.1"
             VALUE "ProductName", "OpenSSH for Windows"
             VALUE "ProductVersion", "OpenSSH_7.6p1 for Windows"
         END

--- a/sshd.c
+++ b/sshd.c
@@ -779,6 +779,7 @@ privsep_preauth(Authctxt *authctxt)
 				error("%s, posix_spawn failed", __func__);
 			posix_spawn_file_actions_destroy(&actions);
 		}
+		pmonitor->m_pid = pid;
 		close(pmonitor->m_recvfd);
 		close(pmonitor->m_log_sendfd);
 		send_config_state(pmonitor->m_sendfd, &cfg);


### PR DESCRIPTION
Fixed the missing child reference in privileged monitor.
Hotfix++ in file version.
