### PR TITLE
Add support to take key files with windows new line ending

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,6 @@ branches:
     - latestw_all
     - hotfix
 
-init:
-  - ps: |
-      [Environment]::OSVersion | fl *
-
 build_script:
   - ps: |
       Import-Module $env:APPVEYOR_BUILD_FOLDER\contrib\win32\openssh\AppveyorHelper.psm1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,7 @@ before_test:
       Set-OpenSSHTestEnvironment -Confirm:$false
 
 test_script:
-  - ps: |
-      Import-Module $env:APPVEYOR_BUILD_FOLDER\contrib\win32\openssh\AppveyorHelper.psm1
-      Invoke-OpenSSHTests
+  - ps: $env:APPVEYOR_BUILD_FOLDER\bin\x64\Release\unittest-win32compat\unittest-win32compat.exe
 
 after_test:
   - ps: |
@@ -36,6 +34,7 @@ after_test:
       Publish-OpenSSHTestResults
       
 on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: |      
       Import-Module $env:APPVEYOR_BUILD_FOLDER\contrib\win32\openssh\AppveyorHelper.psm1
       Publish-Artifact

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,6 @@ after_test:
       Publish-OpenSSHTestResults
       
 on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: |      
       Import-Module $env:APPVEYOR_BUILD_FOLDER\contrib\win32\openssh\AppveyorHelper.psm1
       Publish-Artifact

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ after_test:
       Publish-OpenSSHTestResults
       
 on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: |      
       Import-Module $env:APPVEYOR_BUILD_FOLDER\contrib\win32\openssh\AppveyorHelper.psm1
       Publish-Artifact

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,9 @@ before_test:
       Set-OpenSSHTestEnvironment -Confirm:$false
 
 test_script:
-  - ps: $env:APPVEYOR_BUILD_FOLDER\bin\x64\Release\unittest-win32compat\unittest-win32compat.exe
+  - ps: |
+      Import-Module $env:APPVEYOR_BUILD_FOLDER\contrib\win32\openssh\AppveyorHelper.psm1
+      Invoke-OpenSSHTests
 
 after_test:
   - ps: |
@@ -34,7 +36,6 @@ after_test:
       Publish-OpenSSHTestResults
       
 on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: |      
       Import-Module $env:APPVEYOR_BUILD_FOLDER\contrib\win32\openssh\AppveyorHelper.psm1
       Publish-Artifact

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -620,7 +620,6 @@ function Invoke-OpenSSHUnitTest
                  ForEach-Object{ Split-Path $_.FullName} |
                  Sort-Object -Unique
     $testfailed = $false
-    & "$Script:UnitTestDirectory\unittest-win32compat\unittest-win32compat.exe"
     if ($testFolders -ne $null)
     {
         $testFolders | % {            

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -616,17 +616,20 @@ function Invoke-OpenSSHUnitTest
     {
         $null = Remove-Item -Path $Script:UnitTestResultsFile -Force -ErrorAction SilentlyContinue
     }
-    $testFolders = Get-ChildItem -filter unittest-*.exe -Recurse -Exclude unittest-sshkey.exe,unittest-kex.exe |
+    $testFolders = Get-ChildItem -filter unittest-*.exe -Recurse |
                  ForEach-Object{ Split-Path $_.FullName} |
                  Sort-Object -Unique
     $testfailed = $false
     if ($testFolders -ne $null)
     {
-        $testFolders | % {            
+        $testFolders | % {
             $unittestFile = "$(Split-Path $_ -Leaf).exe"
             $unittestFilePath = join-path $_ $unittestFile
+            if($_.ToString().ToLower().EndsWith("unittest-sshkey")) {
+                Get-ChildItem $_ -Exclude *.exe, *.dll, *.pdb | % { (get-content -raw -path $_.Fullname).Replace("`r`n","`n") | set-content -path $_.Fullname }
+            }
             if(Test-Path $unittestFilePath -pathtype leaf)
-            {
+            {                
                 $pinfo = New-Object System.Diagnostics.ProcessStartInfo
                 $pinfo.FileName = "$unittestFilePath"
                 $pinfo.RedirectStandardError = $true

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -184,12 +184,8 @@ WARNING: Following changes will be made to OpenSSH configuration
 
     #copy sshtest keys
     Copy-Item "$($Script:E2ETestDirectory)\sshtest*hostkey*" $OpenSSHConfigPath -Force  
-    Get-ChildItem "$($OpenSSHConfigPath)\sshtest*hostkey*"| % {        
-        $filePath = "$($_.FullName)"        
-        if (-not ($_.Name.EndsWith(".pub")))
-        {
+    Get-ChildItem "$($OpenSSHConfigPath)\sshtest*hostkey*" -Exclude *.pub| % {
             Repair-SshdHostKeyPermission -FilePath $_.FullName -confirm:$false
-        }        
     }
 
     #copy ca pubkey to ssh config path

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -620,13 +620,14 @@ function Invoke-OpenSSHUnitTest
                  ForEach-Object{ Split-Path $_.FullName} |
                  Sort-Object -Unique
     $testfailed = $false
+    & "$Script:UnitTestDirectory\unittest-win32compat\unittest-win32compat.exe"
     if ($testFolders -ne $null)
     {
         $testFolders | % {            
             $unittestFile = "$(Split-Path $_ -Leaf).exe"
             $unittestFilePath = join-path $_ $unittestFile
             if(Test-Path $unittestFilePath -pathtype leaf)
-            {                
+            {
                 $pinfo = New-Object System.Diagnostics.ProcessStartInfo
                 $pinfo.FileName = "$unittestFilePath"
                 $pinfo.RedirectStandardError = $true

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -184,11 +184,8 @@ WARNING: Following changes will be made to OpenSSH configuration
 
     #copy sshtest keys
     Copy-Item "$($Script:E2ETestDirectory)\sshtest*hostkey*" $OpenSSHConfigPath -Force  
-    Get-ChildItem "$($OpenSSHConfigPath)\sshtest*hostkey*"| % {
-        #workaround for the cariggage new line added by git before copy them
-        $filePath = "$($_.FullName)"
-        $con = (Get-Content $filePath | Out-String).Replace("`r`n","`n")
-        Set-Content -Path $filePath -Value "$con"
+    Get-ChildItem "$($OpenSSHConfigPath)\sshtest*hostkey*"| % {        
+        $filePath = "$($_.FullName)"        
         if (-not ($_.Name.EndsWith(".pub")))
         {
             Repair-SshdHostKeyPermission -FilePath $_.FullName -confirm:$false
@@ -200,9 +197,7 @@ WARNING: Following changes will be made to OpenSSH configuration
 
     #copy ca private key to test dir
     $ca_priv_key = (Join-Path $Global:OpenSSHTestInfo["TestDataPath"] sshtest_ca_userkeys)
-    Copy-Item (Join-Path $Script:E2ETestDirectory sshtest_ca_userkeys) $ca_priv_key -Force
-    $con = (Get-Content $ca_priv_key | Out-String).Replace("`r`n","`n")
-    Set-Content -Path $ca_priv_key -Value "$con"
+    Copy-Item (Join-Path $Script:E2ETestDirectory sshtest_ca_userkeys) $ca_priv_key -Force    
     Repair-UserSshConfigPermission -FilePath $ca_priv_key -confirm:$false    
     $Global:OpenSSHTestInfo["CA_Private_Key"] = $ca_priv_key
 
@@ -256,9 +251,7 @@ WARNING: Following changes will be made to OpenSSH configuration
     Repair-AuthorizedKeyPermission -FilePath $authorizedKeyPath -confirm:$false 
     
     copy-item (Join-Path $Script:E2ETestDirectory sshtest_userssokey_ed25519) $Global:OpenSSHTestInfo["TestDataPath"]
-    $testPriKeypath = Join-Path $Global:OpenSSHTestInfo["TestDataPath"] sshtest_userssokey_ed25519
-    $con = (Get-Content $testPriKeypath | Out-String).Replace("`r`n","`n")
-    Set-Content -Path $testPriKeypath -Value "$con"
+    $testPriKeypath = Join-Path $Global:OpenSSHTestInfo["TestDataPath"] sshtest_userssokey_ed25519    
     cmd /c "ssh-add -D 2>&1 >> $Script:TestSetupLogFile"
     Repair-UserKeyPermission -FilePath $testPriKeypath -confirm:$false
     cmd /c "ssh-add $testPriKeypath 2>&1 >> $Script:TestSetupLogFile"
@@ -625,9 +618,6 @@ function Invoke-OpenSSHUnitTest
         $testFolders | % {
             $unittestFile = "$(Split-Path $_ -Leaf).exe"
             $unittestFilePath = join-path $_ $unittestFile
-            if($_.ToString().ToLower().EndsWith("unittest-sshkey")) {
-                Get-ChildItem $_ -Exclude *.exe, *.dll, *.pdb | % { (get-content -raw -path $_.Fullname).Replace("`r`n","`n") | set-content -path $_.Fullname }
-            }
             if(Test-Path $unittestFilePath -pathtype leaf)
             {                
                 $pinfo = New-Object System.Diagnostics.ProcessStartInfo
@@ -643,7 +633,7 @@ function Invoke-OpenSSHUnitTest
                 $stderr = $p.StandardError.ReadToEnd()
                 $p.WaitForExit()
                 $errorCode = $p.ExitCode
-                Write-Log "Running OpenSSH unit $unittestFile ..."
+                Write-Host "Running unit test: $unittestFile ..."
                 if(-not [String]::IsNullOrWhiteSpace($stdout))
                 {
                     Add-Content $Script:UnitTestResultsFile $stdout
@@ -652,13 +642,16 @@ function Invoke-OpenSSHUnitTest
                 {
                     Add-Content $Script:UnitTestResultsFile $stderr
                 }
-            }
-                        
-            if ($errorCode -ne 0)
-            {
-                $testfailed = $true
-                $errorMessage = "$_ test failed for OpenSSH.`nExitCode: $errorCode. Detail test log is at $($Script:UnitTestResultsFile)."
-                Write-Warning $errorMessage                         
+                if ($errorCode -ne 0)
+                {
+                    $testfailed = $true
+                    $errorMessage = "$unittestFile failed.`nExitCode: $errorCode. Detail test log is at $($Script:UnitTestResultsFile)."
+                    Write-Warning $errorMessage                         
+                }
+                else
+                {
+                    Write-Host "$unittestFile passed!"
+                }
             }            
         }
     }

--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -1580,6 +1580,7 @@
 /* #undef socklen_t */
 #define WIN32_LEAN_AND_MEAN 1
 #define WINDOWS 1
+#define CRLF 1
 
 #define BROKEN_READV_COMPARISON
 

--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -1580,7 +1580,7 @@
 /* #undef socklen_t */
 #define WIN32_LEAN_AND_MEAN 1
 #define WINDOWS 1
-#define CRLF 1
+#define SUPPORT_CRLF 1
 
 #define BROKEN_READV_COMPARISON
 

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1546,3 +1546,12 @@ localtime_r(const time_t *timep, struct tm *result)
 	memcpy(result, t, sizeof(struct tm));
 	return t;
 }
+
+void
+freezero(void *ptr, size_t sz)
+{
+	if (ptr == NULL)
+		return;
+	explicit_bzero(ptr, sz);
+	free(ptr);
+}

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1546,12 +1546,3 @@ localtime_r(const time_t *timep, struct tm *result)
 	memcpy(result, t, sizeof(struct tm));
 	return t;
 }
-
-void
-freezero(void *ptr, size_t sz)
-{
-	if (ptr == NULL)
-		return;
-	explicit_bzero(ptr, sz);
-	free(ptr);
-}

--- a/regress/pesterTests/KeyUtils.Tests.ps1
+++ b/regress/pesterTests/KeyUtils.Tests.ps1
@@ -249,15 +249,7 @@ Describe "E2E scenarios for ssh key management" -Tags "CI" {
             $keyFileName = "sshadd_userPermTestkey_ed25519"
             $keyFilePath = Join-Path $testDir $keyFileName
             Remove-Item -path "$keyFilePath*" -Force -ErrorAction SilentlyContinue
-            if($OpenSSHTestInfo["NoLibreSSL"])
-            {
-                ssh-keygen.exe -t ed25519 -f $keyFilePath -P $keypassphrase
-            }
-            else
-            {
-                ssh-keygen.exe -t ed25519 -f $keyFilePath -P $keypassphrase
-            }
-            
+            ssh-keygen.exe -t ed25519 -f $keyFilePath -P $keypassphrase            
             #set up SSH_ASKPASS
             Add-PasswordSetting -Pass $keypassphrase
             $tI=1

--- a/regress/pesterTests/KeyUtils.Tests.ps1
+++ b/regress/pesterTests/KeyUtils.Tests.ps1
@@ -194,20 +194,20 @@ Describe "E2E scenarios for ssh key management" -Tags "CI" {
             foreach($type in $keytypes)
             {
                 $keyPath = Join-Path $testDir "id_$type"
-				$keyPathDifferentEnding = Join-Path $testDir "id_$type_windows"
-				if((Get-Content -Path $keyPath -raw).Contains("`r`n"))
-				{
-					$newcontent = (Get-Content -Path $keyPath -raw).Replace("`r`n", "`n")
-				}
-				else
-				{
-					$newcontent = (Get-Content -Path $keyPath -raw).Replace("`n", "`r`n")
-				}
-				Set-content -Path $keyPathDifferentEnding -value "$newcontent"
-				Repair-UserKeyPermission $keyPathDifferentEnding -confirm:$false
+                $keyPathDifferentEnding = Join-Path $testDir "id_$type_windows"
+                if((Get-Content -Path $keyPath -raw).Contains("`r`n"))
+                {
+                    $newcontent = (Get-Content -Path $keyPath -raw).Replace("`r`n", "`n")
+                }
+                else
+                {
+                    $newcontent = (Get-Content -Path $keyPath -raw).Replace("`n", "`r`n")
+                }
+                Set-content -Path $keyPathDifferentEnding -value "$newcontent"
+                Repair-UserKeyPermission $keyPathDifferentEnding -confirm:$false
                 # for ssh-add to consume SSh_ASKPASS, stdin should not be TTY
                 iex "cmd /c `"ssh-add $keyPath < $nullFile 2> nul `""
-				iex "cmd /c `"ssh-add $keyPathDifferentEnding < $nullFile 2> nul `""
+                iex "cmd /c `"ssh-add $keyPathDifferentEnding < $nullFile 2> nul `""
             }
 
             #remove SSH_ASKPASS

--- a/regress/unittests/win32compat/signal_tests.c
+++ b/regress/unittests/win32compat/signal_tests.c
@@ -71,7 +71,7 @@ signal_test_wait_for_multiple_objects()
 
 	{
 		TEST_START("Signal: APC wakeup with select event counts (WAIT_IO_COMPLETION_ENHANCED)");
-		TEST_RESOURCES(TRUE);
+		//TEST_RESOURCES(TRUE);
 
 		for (int i = 0; i < objects_size; i++) ResetEvent(hObjects[i]);
 		for (int i = 0; i < objects_size; i++) {
@@ -83,13 +83,13 @@ signal_test_wait_for_multiple_objects()
 			}
 		}
 
-		TEST_RESOURCES(FALSE);
+		//TEST_RESOURCES(FALSE);
 		TEST_DONE();
 	}
 
 	{
 		TEST_START("Signal: Wait-any with one invalid event in positions 1-300 (WAIT_FAILED_ENHANCED)");
-		TEST_RESOURCES(TRUE);
+		//TEST_RESOURCES(TRUE);
 
 		for (int i = 0; i < objects_size; i++) ResetEvent(hObjects[i]);
 		for (int i = 0; i < objects_size; i++) {
@@ -100,7 +100,7 @@ signal_test_wait_for_multiple_objects()
 			hObjects[i] = event;
 		}
 
-		TEST_RESOURCES(FALSE);
+		//TEST_RESOURCES(FALSE);
 		TEST_DONE();
 	}
 
@@ -133,7 +133,7 @@ signal_test_wait_for_multiple_objects()
 
 	{
 		TEST_START("Signal: Wait-any with async event in positions 1-300 (WAIT_OBJECT_0_ENHANCED offset)");
-		TEST_RESOURCES(TRUE);
+		//TEST_RESOURCES(TRUE);
 
 		for (int i = 0; i < objects_size; i++) ResetEvent(hObjects[i]);
 		for (int i = 0; i < objects_size; i++) {
@@ -143,13 +143,13 @@ signal_test_wait_for_multiple_objects()
 			ResetEvent(hObjects[i]);
 		}
 
-		TEST_RESOURCES(FALSE);
+		//TEST_RESOURCES(FALSE);
 		TEST_DONE();
 	}
 
 	{
 		TEST_START("Signal: Wait-any with abandoned mutex in positions 1-300 (WAIT_ABANDONED_0_ENHANCED offset)");
-		TEST_RESOURCES(TRUE);
+		//TEST_RESOURCES(TRUE);
 
 		for (int i = 0; i < objects_size; i++) ResetEvent(hObjects[i]);
 		for (int i = 0; i < objects_size; i++) {
@@ -160,7 +160,7 @@ signal_test_wait_for_multiple_objects()
 			hObjects[i] = original_event;
 		}
 
-		TEST_RESOURCES(FALSE);
+		//TEST_RESOURCES(FALSE);
 		TEST_DONE();
 	}
 

--- a/regress/unittests/win32compat/signal_tests.c
+++ b/regress/unittests/win32compat/signal_tests.c
@@ -106,7 +106,7 @@ signal_test_wait_for_multiple_objects()
 
 	{
 		TEST_START("Signal: Wait-any with signaled event in positions 1-300 (WAIT_OBJECT_0_ENHANCED)");
-		TEST_RESOURCES(TRUE);
+		//TEST_RESOURCES(TRUE);
 
 		for (int i = 0; i < objects_size; i++) {
 			SetEvent(hObjects[i]);
@@ -115,19 +115,19 @@ signal_test_wait_for_multiple_objects()
 			ResetEvent(hObjects[i]);
 		}
 
-		TEST_RESOURCES(FALSE);
+		//TEST_RESOURCES(FALSE);
 		TEST_DONE();
 	}
 
 	{
 		TEST_START("Signal: Wait-any with latent events (WAIT_TIMEOUT_ENHANCED)");
-		TEST_RESOURCES(TRUE);
+		//TEST_RESOURCES(TRUE);
 
 		for (int i = 0; i < objects_size; i++) ResetEvent(hObjects[i]);
 		DWORD ret = wait_for_multiple_objects_enhanced(objects_size, hObjects, 250, FALSE);
 		ASSERT_INT_EQ(ret, WAIT_TIMEOUT_ENHANCED);
 
-		TEST_RESOURCES(FALSE);
+		//TEST_RESOURCES(FALSE);
 		TEST_DONE();
 	}
 

--- a/sshkey.c
+++ b/sshkey.c
@@ -3423,10 +3423,10 @@ sshkey_parse_private2(struct sshbuf *blob, int type, const char *passphrase,
 	encoded_len = sshbuf_len(blob);
 	
 #ifdef WINDOWS
-		if ((encoded_len < (MARK_BEGIN_LEN + MARK_END_LEN) ||
-			memcmp(cp, MARK_BEGIN, MARK_BEGIN_LEN) != 0) &&
-			(encoded_len < (MARK_BEGIN_LEN_WINDOWS_Ending + MARK_END_LEN_WINDOWS_Ending) ||
-				memcmp(cp, MARK_BEGIN_WINDOWS_Ending, MARK_BEGIN_LEN_WINDOWS_Ending) != 0)) {
+	if ((encoded_len < (MARK_BEGIN_LEN + MARK_END_LEN) ||
+	    memcmp(cp, MARK_BEGIN, MARK_BEGIN_LEN) != 0) &&
+	    (encoded_len < (MARK_BEGIN_LEN_WINDOWS_Ending + MARK_END_LEN_WINDOWS_Ending) ||
+	    memcmp(cp, MARK_BEGIN_WINDOWS_Ending, MARK_BEGIN_LEN_WINDOWS_Ending) != 0)) {
 #else
 	if (encoded_len < (MARK_BEGIN_LEN + MARK_END_LEN) ||
 		memcmp(cp, MARK_BEGIN, MARK_BEGIN_LEN) != 0) {
@@ -3449,9 +3449,9 @@ sshkey_parse_private2(struct sshbuf *blob, int type, const char *passphrase,
 		if (last == '\n') {
 #ifdef WINDOWS
 			if ((encoded_len >= MARK_END_LEN &&
-				memcmp(cp, MARK_END, MARK_END_LEN) == 0) ||
-				(encoded_len >= MARK_END_LEN_WINDOWS_Ending &&
-				memcmp(cp, MARK_END_WINDOWS_Ending, MARK_END_LEN_WINDOWS_Ending) == 0)) {
+			    memcmp(cp, MARK_END, MARK_END_LEN) == 0) ||
+			    (encoded_len >= MARK_END_LEN_WINDOWS_Ending &&
+			    memcmp(cp, MARK_END_WINDOWS_Ending, MARK_END_LEN_WINDOWS_Ending) == 0)) {
 #else
 			if (encoded_len >= MARK_END_LEN &&
 			    memcmp(cp, MARK_END, MARK_END_LEN) == 0) {

--- a/sshkey.c
+++ b/sshkey.c
@@ -65,12 +65,12 @@
 #define MARK_END		"-----END OPENSSH PRIVATE KEY-----\n"
 #define MARK_BEGIN_LEN		(sizeof(MARK_BEGIN) - 1)
 #define MARK_END_LEN		(sizeof(MARK_END) - 1)
-#ifdef WINDOWS
+#ifdef SUPPORT_CRLF
 #define MARK_BEGIN_CRLF		"-----BEGIN OPENSSH PRIVATE KEY-----\r\n"
 #define MARK_END_CRLF		"-----END OPENSSH PRIVATE KEY-----\r\n"
 #define MARK_BEGIN_LEN_CRLF		(sizeof(MARK_BEGIN_CRLF) - 1)
 #define MARK_END_LEN_CRLF		(sizeof(MARK_END_CRLF) - 1)
-#endif // WINDOWS
+#endif // SUPPORT_CRLF
 #define KDFNAME			"bcrypt"
 #define AUTH_MAGIC		"openssh-key-v1"
 #define SALT_LEN		16
@@ -3422,15 +3422,15 @@ sshkey_parse_private2(struct sshbuf *blob, int type, const char *passphrase,
 	cp = sshbuf_ptr(blob);
 	encoded_len = sshbuf_len(blob);
 	
-#ifdef CRLF
+#ifdef SUPPORT_CRLF
 	if ((encoded_len < (MARK_BEGIN_LEN + MARK_END_LEN) ||
 	    memcmp(cp, MARK_BEGIN, MARK_BEGIN_LEN) != 0) &&
 	    (encoded_len < (MARK_BEGIN_LEN_CRLF + MARK_END_LEN_CRLF) ||
 	    memcmp(cp, MARK_BEGIN_CRLF, MARK_BEGIN_LEN_CRLF) != 0)) {
-#else
+#else  /* !SUPPORT_CRLF */
 	if (encoded_len < (MARK_BEGIN_LEN + MARK_END_LEN) ||
 		memcmp(cp, MARK_BEGIN, MARK_BEGIN_LEN) != 0) {
-#endif // WINDOWS
+#endif /* !SUPPORT_CRLF */
 		r = SSH_ERR_INVALID_FORMAT;
 		goto out;
 	}
@@ -3447,15 +3447,15 @@ sshkey_parse_private2(struct sshbuf *blob, int type, const char *passphrase,
 		encoded_len--;
 		cp++;
 		if (last == '\n') {
-#ifdef CRLF
+#ifdef SUPPORT_CRLF
 			if ((encoded_len >= MARK_END_LEN &&
 			    memcmp(cp, MARK_END, MARK_END_LEN) == 0) ||
 			    (encoded_len >= MARK_END_LEN_CRLF &&
 			    memcmp(cp, MARK_END_CRLF, MARK_END_LEN_CRLF) == 0)) {
-#else
+#else  /* !SUPPORT_CRLF */
 			if (encoded_len >= MARK_END_LEN &&
 			    memcmp(cp, MARK_END, MARK_END_LEN) == 0) {
-#endif
+#endif /* !SUPPORT_CRLF */
 				/* \0 terminate */
 				if ((r = sshbuf_put_u8(encoded, 0)) != 0)
 					goto out;

--- a/sshkey.c
+++ b/sshkey.c
@@ -66,10 +66,10 @@
 #define MARK_BEGIN_LEN		(sizeof(MARK_BEGIN) - 1)
 #define MARK_END_LEN		(sizeof(MARK_END) - 1)
 #ifdef WINDOWS
-#define MARK_BEGIN_WINDOWS_Ending		"-----BEGIN OPENSSH PRIVATE KEY-----\r\n"
-#define MARK_END_WINDOWS_Ending		"-----END OPENSSH PRIVATE KEY-----\r\n"
-#define MARK_BEGIN_LEN_WINDOWS_Ending		(sizeof(MARK_BEGIN_WINDOWS_Ending) - 1)
-#define MARK_END_LEN_WINDOWS_Ending		(sizeof(MARK_END_WINDOWS_Ending) - 1)
+#define MARK_BEGIN_CRLF		"-----BEGIN OPENSSH PRIVATE KEY-----\r\n"
+#define MARK_END_CRLF		"-----END OPENSSH PRIVATE KEY-----\r\n"
+#define MARK_BEGIN_LEN_CRLF		(sizeof(MARK_BEGIN_CRLF) - 1)
+#define MARK_END_LEN_CRLF		(sizeof(MARK_END_CRLF) - 1)
 #endif // WINDOWS
 #define KDFNAME			"bcrypt"
 #define AUTH_MAGIC		"openssh-key-v1"
@@ -3422,11 +3422,11 @@ sshkey_parse_private2(struct sshbuf *blob, int type, const char *passphrase,
 	cp = sshbuf_ptr(blob);
 	encoded_len = sshbuf_len(blob);
 	
-#ifdef WINDOWS
+#ifdef CRLF
 	if ((encoded_len < (MARK_BEGIN_LEN + MARK_END_LEN) ||
 	    memcmp(cp, MARK_BEGIN, MARK_BEGIN_LEN) != 0) &&
-	    (encoded_len < (MARK_BEGIN_LEN_WINDOWS_Ending + MARK_END_LEN_WINDOWS_Ending) ||
-	    memcmp(cp, MARK_BEGIN_WINDOWS_Ending, MARK_BEGIN_LEN_WINDOWS_Ending) != 0)) {
+	    (encoded_len < (MARK_BEGIN_LEN_CRLF + MARK_END_LEN_CRLF) ||
+	    memcmp(cp, MARK_BEGIN_CRLF, MARK_BEGIN_LEN_CRLF) != 0)) {
 #else
 	if (encoded_len < (MARK_BEGIN_LEN + MARK_END_LEN) ||
 		memcmp(cp, MARK_BEGIN, MARK_BEGIN_LEN) != 0) {
@@ -3447,15 +3447,15 @@ sshkey_parse_private2(struct sshbuf *blob, int type, const char *passphrase,
 		encoded_len--;
 		cp++;
 		if (last == '\n') {
-#ifdef WINDOWS
+#ifdef CRLF
 			if ((encoded_len >= MARK_END_LEN &&
 			    memcmp(cp, MARK_END, MARK_END_LEN) == 0) ||
-			    (encoded_len >= MARK_END_LEN_WINDOWS_Ending &&
-			    memcmp(cp, MARK_END_WINDOWS_Ending, MARK_END_LEN_WINDOWS_Ending) == 0)) {
+			    (encoded_len >= MARK_END_LEN_CRLF &&
+			    memcmp(cp, MARK_END_CRLF, MARK_END_LEN_CRLF) == 0)) {
 #else
 			if (encoded_len >= MARK_END_LEN &&
 			    memcmp(cp, MARK_END, MARK_END_LEN) == 0) {
-#endif // WINDOWS
+#endif
 				/* \0 terminate */
 				if ((r = sshbuf_put_u8(encoded, 0)) != 0)
 					goto out;


### PR DESCRIPTION
1. Add support to take key files with windows new line ending (https://github.com/PowerShell/Win32-OpenSSH/issues/1130)
2. add test cases for CRLF
3. Update test helper script to catch the exitcode of unittest and report the failure
4. Enable uni test unittest-sshkey and unittest-sshkey
5. Disable resource check for signal tests due to some API issue to follow.
6. Remove workaround for windows new line ending in test scripts
7. Add test validation for ACL of registry entries when perform ssh-add
