### PR TITLE
Enable SFTP chroot support

### DIFF
--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -439,10 +439,12 @@ fileio_open(const char *path_utf8, int flags, mode_t mode)
 	}
 
 	/* if opening null device, point to Windows equivalent */
-	if (strncmp(path_utf8, NULL_DEVICE, sizeof(NULL_DEVICE)) == 0) 
-		path_utf8 = NULL_DEVICE_WIN;
+	if (strncmp(path_utf8, NULL_DEVICE, sizeof(NULL_DEVICE)) == 0)
+		path_utf16 = utf8_to_utf16(NULL_DEVICE_WIN);
+	else
+		path_utf16 = resolved_path_utf16(path_utf8);
 
-	if ((path_utf16 = resolved_path_utf16(path_utf8)) == NULL) {
+	if (path_utf16 == NULL) {
 		errno = ENOMEM;
 		debug3("utf8_to_utf16 failed for file:%s error:%d", path_utf8, GetLastError());
 		return NULL;

--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -96,6 +96,7 @@ errno_from_Win32Error(int win32_error)
 		return EEXIST;
 	case ERROR_FILE_NOT_FOUND:
 	case ERROR_PATH_NOT_FOUND:
+	case ERROR_INVALID_NAME:
 		return ENOENT;
 	default:
 		return win32_error;

--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -422,7 +422,7 @@ cleanup:
 	return ret;
 }
 
-/* return 1 if true, 0 otherwise */
+/* returns 1 if true, 0 otherwise */
 int
 file_in_chroot_jail(HANDLE handle, const char* path_utf8) {
 	/* ensure final path is within chroot */

--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -433,7 +433,6 @@ file_in_chroot_jail(HANDLE handle, const char* path_utf8) {
 	}
 	final_path = path_buf + 4;
 	to_wlower_case(final_path);
-	to_wlower_case(path_utf8);
 	if ((wcslen(final_path) < wcslen(chroot_pathw)) ||
 		memcmp(final_path, chroot_pathw, 2 * wcslen(chroot_pathw)) != 0 ||
 		final_path[wcslen(chroot_pathw)] != '\\') {

--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -433,10 +433,11 @@ file_in_chroot_jail(HANDLE handle, const char* path_utf8) {
 	}
 	final_path = path_buf + 4;
 	to_wlower_case(final_path);
+	to_wlower_case(path_utf8);
 	if ((wcslen(final_path) < wcslen(chroot_pathw)) ||
 		memcmp(final_path, chroot_pathw, 2 * wcslen(chroot_pathw)) != 0 ||
 		final_path[wcslen(chroot_pathw)] != '\\') {
-		debug4("access denied due to attempt to escape chroot jail");
+		debug3("access denied due to attempt to escape chroot jail");
 		return 0;
 	}
 

--- a/contrib/win32/win32compat/inc/dirent.h
+++ b/contrib/win32/win32compat/inc/dirent.h
@@ -19,8 +19,8 @@ struct dirent {
 
 typedef struct DIR_ DIR;
 
-DIR * opendir(const char *name);
-int closedir(DIR *dirp);
-struct dirent *readdir(void *avp);
+DIR * opendir(const char*);
+int closedir(DIR*);
+struct dirent *readdir(void*);
 
 #endif

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -132,6 +132,7 @@ char* _sys_errlist_ext[] = {
 	"Operation would block"					/* EWOULDBLOCK     140 */
 };
 
+/* chroot state */
 char* chroot_path = NULL;
 int chroot_path_len = 0;
 /* UTF-16 version of the above */
@@ -285,7 +286,6 @@ w32_fopen_utf8(const char *input_path, const char *mode)
 		goto cleanup;
 	}	
 
-	
 	if (chroot_pathw && !nonfs_dev) {
 		/* ensure final path is within chroot */
 		HANDLE h = (HANDLE)_get_osfhandle(_fileno(f));
@@ -826,7 +826,7 @@ w32_getcwd(char *buffer, int maxlen)
 			return NULL;
 		}
 
-		/* is cwb chroot ?*/
+		/* is cwd chroot ?*/
 		if (c == '\0') {
 			buffer[0] = '\\';
 			buffer[1] = '\0';

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -967,13 +967,11 @@ resolved_path_utf16(const char *input_path)
 		return NULL;
 
 	if (chroot_path) {
-		wchar_t* wchroot = utf8_to_utf16(chroot_path);
-		wchar_t * resolved_path_new = malloc(2 * (wcslen(wchroot) + wcslen(resolved_path) + 1));
+		wchar_t * resolved_path_new = malloc(2 * (wcslen(chroot_pathw) + wcslen(resolved_path) + 1));
 		resolved_path_new[0] = L'\0';
-		wcscat(resolved_path_new, wchroot);
+		wcscat(resolved_path_new, chroot_pathw);
 		wcscat(resolved_path_new, resolved_path);
 		free(resolved_path);
-		free(wchroot);
 		resolved_path = resolved_path_new;
 	}
 
@@ -1395,6 +1393,13 @@ to_lower_case(char *s)
 		*s = tolower((u_char)*s);
 }
 
+void 
+to_wlower_case(wchar_t *s)
+{
+	for (; *s; s++)
+		*s = towlower(*s);
+}
+
 static int
 get_final_mode(int allow_mode, int deny_mode)
 {	
@@ -1601,14 +1606,10 @@ chroot(const char *path)
 {
 	/* TODO: validate and normalize path */
 
-	;
+	chroot_path = _strdup(path);
+	to_lower_case(chroot_path);
+	chroot_pathw = utf8_to_utf16(chroot_path);
 
-	if ((chroot_path = _strdup(path)) == NULL ||
-	    (chroot_pathw = utf8_to_utf16(path)) == NULL) {
-		errno = ENOMEM;
-		return -1;
-	}
-	
 	/* TODO - set the env variable just in time in a posix_spawn_chroot like API */
 #define POSIX_CHROOTW L"c28fc6f98a2c44abbbd89d6a3037d0d9_POSIX_CHROOT"
 	_wputenv_s(POSIX_CHROOTW, chroot_pathw);

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -920,12 +920,15 @@ realpath(const char *path, char resolved[PATH_MAX])
 		return NULL;
 	}
 
-	if (path_len == 1 && path[0] == '/') {
+	/* resolve root directory to the same */
+	if (path_len == 1 && (path[0] == '/' || path[0] == '\\')) {
 		resolved[0] = '/';
 		resolved[1] = '\0';
 		return resolved;
 	}
 
+	/* resolve this common case scenario to root */
+	/* "cd .." from within a drive root */
 	if (path_len == 6) {
 		char *tmplate = "/x:/..";
 		strcat(resolved, path);
@@ -940,8 +943,11 @@ realpath(const char *path, char resolved[PATH_MAX])
 	if (chroot_path) {
 		resolved[0] = '\0';
 		strcat(resolved, chroot_path);
-		if (path[0] != '/')
+		/* if path is relative, add cwd within chroot */
+		if (path[0] != '/' || path[0] != '\\') {
+			w32_getcwd(resolved + chroot_path_len, PATH_MAX - chroot_path_len);
 			strcat(resolved, "/");
+		}
 		strcat(resolved, path);
 	}
 	else if ((path_len >= 2) && (path[0] == '/') && path[1] && (path[2] == ':')) {

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -944,7 +944,7 @@ realpath(const char *path, char resolved[PATH_MAX])
 		resolved[0] = '\0';
 		strcat(resolved, chroot_path);
 		/* if path is relative, add cwd within chroot */
-		if (path[0] != '/' || path[0] != '\\') {
+		if (path[0] != '/' && path[0] != '\\') {
 			w32_getcwd(resolved + chroot_path_len, PATH_MAX - chroot_path_len);
 			strcat(resolved, "/");
 		}

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -929,7 +929,7 @@ realpath(const char *path, char resolved[PATH_MAX])
 
 	/* resolve this common case scenario to root */
 	/* "cd .." from within a drive root */
-	if (path_len == 6) {
+	if (path_len == 6 && !chroot_path) {
 		char *tmplate = "/x:/..";
 		strcat(resolved, path);
 		resolved[1] = 'x';
@@ -972,7 +972,7 @@ realpath(const char *path, char resolved[PATH_MAX])
 	}
 
 	if (chroot_path) {
-		if (strlen(tempPath) <= strlen(chroot_path)) {
+		if (strlen(tempPath) < strlen(chroot_path)) {
 			errno = EACCES;
 			return NULL;
 		}
@@ -982,7 +982,13 @@ realpath(const char *path, char resolved[PATH_MAX])
 		}
 
 		resolved[0] = '\0';
-		strcat(resolved, tempPath + strlen(chroot_path));
+
+		
+		if (strlen(tempPath) == strlen(chroot_path))
+			/* realpath is the same as chroot_path */
+			strcat(resolved, "\\");
+		else
+			strcat(resolved, tempPath + strlen(chroot_path));
 
 		if (resolved[0] != '\\') {
 			errno = EACCES;

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -51,3 +51,4 @@ HANDLE get_user_token(char* user, int impersonation);
 int load_user_profile(HANDLE user_token, char* user);
 int create_directory_withsddl(wchar_t *path, wchar_t *sddl);
 int is_absolute_path(const char *);
+int file_in_chroot_jail(HANDLE, const char*);

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -28,6 +28,7 @@
 static char *machine_domain_name;
 
 extern char* chroot_path;
+extern int chroot_path_len;
 extern wchar_t* chroot_pathw;
 
 /* removes first '/' for Windows paths that are unix styled. Ex: /c:/ab.cd */

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -24,6 +24,9 @@
 
 static char *machine_domain_name;
 
+extern char* chroot_path;
+extern wchar_t* chroot_pathw;
+
 /* removes first '/' for Windows paths that are unix styled. Ex: /c:/ab.cd */
 wchar_t * resolved_path_utf16(const char *);
 void w32posix_initialize();
@@ -38,6 +41,7 @@ void file_time_to_unix_time(const LPFILETIME, time_t *);
 int file_attr_to_st_mode(wchar_t * path, DWORD attributes);
 void invalid_parameter_handler(const wchar_t *, const wchar_t *, const wchar_t *, unsigned int, uintptr_t);
 void to_lower_case(char *s);
+void to_wlower_case(wchar_t *s);
 int get_machine_domain_name(wchar_t *domain, int size);
 wchar_t* get_program_data_path();
 HANDLE get_user_token(char* user);

--- a/contrib/win32/win32compat/no-ops.c
+++ b/contrib/win32/win32compat/no-ops.c
@@ -90,19 +90,14 @@ innetgr(const char *netgroup, const char *host, const char *user, const char *do
 	return -1;
 }
 
+
+/* sshd.c */
 int
-chroot(const char *path)
+initgroups(const char *user, gid_t group)
 {
 	return 0;
 }
 
-int
-initgroups(const char *user, gid_t group)
-{
-	return -1;
-}
-
-/* sshd.c */
 int
 setgroups(gid_t group, char* name)
 {

--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -324,7 +324,7 @@ user_from_uid(uid_t uid, int nouser)
 uid_t
 getuid(void)
 {
-	return 0;
+	return 1;
 }
 
 gid_t
@@ -336,7 +336,7 @@ getgid(void)
 uid_t
 geteuid(void)
 {
-	return 0;
+	return 1;
 }
 
 gid_t

--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -318,6 +318,11 @@ STARTUPINFO inputSi;
 		goto cleanup;		\
 } while(0)
 
+void     
+debug3(const char *s, ...) {
+	return;
+}
+
 int
 ConSRWidth()
 {

--- a/contrib/win32/win32compat/utf.c
+++ b/contrib/win32/win32compat/utf.c
@@ -30,7 +30,9 @@
 
 #include <Windows.h>
 #include "inc\utf.h"
+#include "Debug.h"
 
+/*on error returns NULL and sets errno*/
 wchar_t *
 utf8_to_utf16(const char *utf8)
 {
@@ -38,8 +40,11 @@ utf8_to_utf16(const char *utf8)
 	wchar_t* utf16 = NULL;
 	if ((needed = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, NULL, 0)) == 0 ||
 	    (utf16 = malloc(needed * sizeof(wchar_t))) == NULL ||
-	    MultiByteToWideChar(CP_UTF8, 0, utf8, -1, utf16, needed) == 0)
+	    MultiByteToWideChar(CP_UTF8, 0, utf8, -1, utf16, needed) == 0) {
+		debug3("failed to convert utf8 payload:%s error:%d", utf8, GetLastError());
+		errno = ENOMEM;
 		return NULL;
+	}
 
 	return utf16;
 }

--- a/contrib/win32/win32compat/w32-sshfileperm.c
+++ b/contrib/win32/win32compat/w32-sshfileperm.c
@@ -71,7 +71,6 @@ check_secure_file_permission(const char *input_path, struct passwd * pw)
 
 	if ((path_utf16 = resolved_path_utf16(input_path)) == NULL) {
 		ret = -1;
-		errno = ENOMEM;
 		goto cleanup;
 	}
 

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -123,7 +123,7 @@ fd_table_initialize()
 		_wdupenv_s(&chroot_pathw, NULL, POSIX_CHROOTW);
 		if (chroot_pathw != NULL) {
 			chroot_path = utf16_to_utf8(chroot_pathw);
-			_wputenv_s(POSIX_CHROOTW, L"");
+			chroot_path_len = strlen(chroot_path);
 		}
 	}
 

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -73,9 +73,6 @@ void fd_decode_state(char*);
 /* __progname */
 char* __progname = "";
 
-extern char* chroot_path;
-extern wchar_t* chroot_pathw;
-
 /* initializes mapping table*/
 static int
 fd_table_initialize()

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -67,16 +67,19 @@ HANDLE main_thread;
 void fd_table_set(struct w32_io* pio, int index);
 
 void fd_decode_state(char*);
-#define POSIX_STATE_ENV "c28fc6f98a2c44abbbd89d6a3037d0d9_POSIX_STATE"
+#define POSIX_FD_STATE "c28fc6f98a2c44abbbd89d6a3037d0d9_POSIX_FD_STATE"
+#define POSIX_CHROOTW L"c28fc6f98a2c44abbbd89d6a3037d0d9_POSIX_CHROOT"
 
 /* __progname */
 char* __progname = "";
+
+extern char* chroot_path;
+extern wchar_t* chroot_pathw;
 
 /* initializes mapping table*/
 static int
 fd_table_initialize()
 {
-	char *posix_state;
 	struct w32_io *pio;
 	HANDLE wh;
 	/* table entries representing std in, out and error*/
@@ -101,17 +104,32 @@ fd_table_initialize()
 		}
 	}
 
-	_dupenv_s(&posix_state, NULL, POSIX_STATE_ENV);
-	/*TODO - validate parent process - to accomodate these scenarios -
-	* A posix parent process launches a regular process that inturn launches a posix child process
-	* In this case the posix child process may misinterpret POSIX_STATE_ENV set by grand parent
-	*/
 
-	if (NULL != posix_state) {
-		fd_decode_state(posix_state);
-		free(posix_state);
-		_putenv_s(POSIX_STATE_ENV, "");
+	/* decode fd state if any */
+	{
+		char *posix_fd_state;
+		_dupenv_s(&posix_fd_state, NULL, POSIX_FD_STATE);
+		/*TODO - validate parent process - to accomodate these scenarios -
+		* A posix parent process launches a regular process that inturn launches a posix child process
+		* In this case the posix child process may misinterpret POSIX_FD_STATE set by grand parent
+		*/
+
+		if (NULL != posix_fd_state) {
+			fd_decode_state(posix_fd_state);
+			free(posix_fd_state);
+			_putenv_s(POSIX_FD_STATE, "");
+		}
 	}
+
+	/* decode chroot if any */
+	{
+		_wdupenv_s(&chroot_pathw, NULL, POSIX_CHROOTW);
+		if (chroot_pathw != NULL) {
+			chroot_path = utf16_to_utf8(chroot_pathw);
+			_wputenv_s(POSIX_CHROOTW, L"");
+		}
+	}
+
 	return 0;
 }
 
@@ -1235,7 +1253,7 @@ posix_spawn_internal(pid_t *pidp, const char *path, const posix_spawn_file_actio
 	if ((fd_info = fd_encode_state(file_actions, aux_handles)) == NULL)
 		goto cleanup;
 
-	if (_putenv_s(POSIX_STATE_ENV, fd_info) != 0)
+	if (_putenv_s(POSIX_FD_STATE, fd_info) != 0)
 		goto cleanup;
 	i = spawn_child_internal(argv[0], argv + 1, stdio_handles[STDIN_FILENO], stdio_handles[STDOUT_FILENO], stdio_handles[STDERR_FILENO], sc_flags, user_token);
 	if (i == -1)
@@ -1244,7 +1262,7 @@ posix_spawn_internal(pid_t *pidp, const char *path, const posix_spawn_file_actio
 		*pidp = i;
 	ret = 0;
 cleanup:
-	_putenv_s(POSIX_STATE_ENV, "");
+	_putenv_s(POSIX_FD_STATE, "");
 	for (i = 0; i <= STDERR_FILENO; i++) {
 		if (stdio_handles[i] != NULL) {
 			if (fd_table.w32_ios[file_actions->stdio_redirect[i]]->type == SOCK_FD)

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -122,7 +122,8 @@ fd_table_initialize()
 	{
 		_wdupenv_s(&chroot_pathw, NULL, POSIX_CHROOTW);
 		if (chroot_pathw != NULL) {
-			chroot_path = utf16_to_utf8(chroot_pathw);
+			if ((chroot_path = utf16_to_utf8(chroot_pathw)) == NULL)
+				return -1;
 			chroot_path_len = strlen(chroot_path);
 		}
 	}

--- a/contrib/win32/win32compat/win32_dirent.c
+++ b/contrib/win32/win32compat/win32_dirent.c
@@ -48,9 +48,9 @@ struct DIR_ {
 #define ATTR_ROOTDIR  UINT_MAX
 
 /* Enumerate all devices which have drive name.
-   Return a DIR stream on the root directory, or NULL if it could not be enumerated. */
+Return a DIR stream on the root directory, or NULL if it could not be enumerated. */
 DIR *
-openrootdir(const char *name)
+openrootdir()
 {
 	int hr = 0;
 	DWORD dw;
@@ -104,14 +104,13 @@ opendir(const char *name)
 	wchar_t* wname = NULL;
 	size_t len;
 
-	/* Detect root dir */
-	if (name && strcmp(name, "/") == 0)
-		return openrootdir(name);
-
 	if ((wname = resolved_path_utf16(name)) == NULL) {
 		errno = ENOMEM;
 		return NULL;
 	}
+	/* Detect root dir */
+	if (wcscmp(wname, L"/") == 0)
+		return openrootdir();
 
 	convertToBackslashW(wname);
 	len = wcslen(wname);

--- a/contrib/win32/win32compat/win32_dirent.c
+++ b/contrib/win32/win32compat/win32_dirent.c
@@ -104,10 +104,9 @@ opendir(const char *name)
 	wchar_t* wname = NULL;
 	size_t len;
 
-	if ((wname = resolved_path_utf16(name)) == NULL) {
-		errno = ENOMEM;
+	if ((wname = resolved_path_utf16(name)) == NULL) 
 		return NULL;
-	}
+
 	/* Detect root dir */
 	if (wcscmp(wname, L"/") == 0)
 		return openrootdir();

--- a/platform.c
+++ b/platform.c
@@ -82,7 +82,7 @@ platform_post_fork_child(void)
 int
 platform_privileged_uidswap(void)
 {
-#ifdef HAVE_CYGWIN
+#if defined(HAVE_CYGWIN) || defined(WINDOWS)
 	/* uid 0 is not special on Cygwin so always try */
 	return 1;
 #else

--- a/regress/unittests/win32compat/miscellaneous_tests.c
+++ b/regress/unittests/win32compat/miscellaneous_tests.c
@@ -301,11 +301,11 @@ test_chroot()
 void
 miscellaneous_tests()
 {
-	//test_ioctl();
-	//test_path_conversion_utilities();
-	//test_sanitizedpath();
-	//test_pw();
-	//test_realpath();
-	//test_statvfs();
+	test_ioctl();
+	test_path_conversion_utilities();
+	test_sanitizedpath();
+	test_pw();
+	test_realpath();
+	test_statvfs();
 	test_chroot();
 }

--- a/regress/unittests/win32compat/miscellaneous_tests.c
+++ b/regress/unittests/win32compat/miscellaneous_tests.c
@@ -210,15 +210,26 @@ test_chroot()
 	/* test directory setup */
 	_wsystem(L"RD /S /Q chroot-testdir >NUL 2>&1");
 	CreateDirectoryW(L"chroot-testdir", NULL);
+	CreateDirectoryW(L"chroot-testdir\\world", NULL);
+	_wsystem(L"echo in-world > chroot-testdir\\world\\w.Txt");
 	CreateDirectoryW(L"chroot-testdir\\jail", NULL);
 	CreateDirectoryW(L"chroot-testdir\\jail\\d1", NULL);
-	_wsystem(L"echo sample-payload > chroot-testdir\\jail\\d1\\F.Txt");
-	CreateDirectoryW(L"chroot-testdir\\jail\\d2", NULL);
+	_wsystem(L"echo in-jail > chroot-testdir\\jail\\d1\\j.Txt");
+	/* create links to world within jail */
+	_wsystem(L"mklink /D chroot-testdir\\jail\\world-sl ..\\world");
+	_wsystem(L"mklink /J chroot-testdir\\jail\\world-jn chroot-testdir\\world");
 		
 	TEST_START("chroot on invalid path");
 	ASSERT_INT_EQ(chroot("blah"), -1);
 	ASSERT_INT_EQ(chroot("\\c:\\blah"), -1);
 	ASSERT_INT_EQ(chroot("/c:/blah"), -1);
+	TEST_DONE();
+
+	TEST_START("access world before chroot");
+	ASSERT_INT_NE(fd = open("chroot-testdir\\jail\\world-jn\\w.Txt", 0), -1);
+	close(fd);
+	ASSERT_PTR_NE(f = fopen("chroot-testdir\\jail\\world-jn\\w.Txt", "r"), NULL);
+	fclose(f);
 	TEST_DONE();
 
 	TEST_START("real chroot now");
@@ -245,30 +256,44 @@ test_chroot()
 	TEST_DONE();
 
 	TEST_START("file io within jail");
-	ASSERT_INT_NE(fd = open("\\d1\\f.txt", 0), -1);
+	ASSERT_INT_NE(fd = open("\\d1\\j.txt", 0), -1);
 	close(fd);
-	ASSERT_INT_NE(fd = open("\\d1/f.txt", 0), -1);
+	ASSERT_INT_NE(fd = open("\\d1/j.txt", 0), -1);
 	close(fd);
-	ASSERT_INT_NE(fd = open("/d1/f.txt", 0), -1);
+	ASSERT_INT_NE(fd = open("/d1/j.txt", 0), -1);
 	close(fd);
 	ASSERT_INT_NE(fd = open("/dev/null", 0), -1);
 	close(fd);
-	ASSERT_PTR_NE(f = fopen("\\d1\\f.txt", "r"), NULL);
+	ASSERT_PTR_NE(f = fopen("\\d1\\j.txt", "r"), NULL);
 	fclose(f);
 	ASSERT_PTR_NE(f = fopen("/dev/null", "w"), NULL);
 	fclose(f);
 	ASSERT_INT_EQ(chdir("/"), 0);
-	ASSERT_INT_NE(fd = open("d1/f.txt", 0), -1);
+	ASSERT_INT_NE(fd = open("d1/j.txt", 0), -1);
 	close(fd);
-	ASSERT_PTR_NE(f = fopen("d1\\f.txt", "r"), NULL);
+	ASSERT_PTR_NE(f = fopen("d1\\j.txt", "r"), NULL);
 	fclose(f);
 	ASSERT_INT_EQ(chdir("\\d1"), 0);
-	ASSERT_INT_NE(fd = open("f.txt", 0), -1);
+	ASSERT_INT_NE(fd = open("j.txt", 0), -1);
 	close(fd);
-	ASSERT_PTR_NE(f = fopen("f.txt", "r"), NULL);
+	ASSERT_PTR_NE(f = fopen("j.txt", "r"), NULL);
 	fclose(f);
-
 	TEST_DONE();
+
+	TEST_START("access world after chroot");
+	ASSERT_INT_EQ(chdir("/"), 0);
+	ASSERT_INT_EQ(fd = open(test_root, 0), -1);
+	ASSERT_INT_EQ(errno, ENOENT);
+	ASSERT_INT_EQ(fd = open("world-jn\\w.Txt", 0), -1);
+	ASSERT_INT_EQ(errno, EACCES);
+	ASSERT_PTR_EQ(f = fopen("world-jn\\w.Txt", "r"), NULL);
+	ASSERT_INT_EQ(errno, EACCES); 
+	ASSERT_INT_EQ(fd = open("world-sl\\w.Txt", 0), -1);
+	ASSERT_INT_EQ(errno, EACCES); 
+	ASSERT_PTR_EQ(f = fopen("world-sl\\w.Txt", "r"), NULL);
+	ASSERT_INT_EQ(errno, EACCES); 
+	TEST_DONE();
+
 
 	//_wsystem(L"RD /S /Q chroot-testdir >NUL 2>&1");
 }

--- a/regress/unittests/win32compat/miscellaneous_tests.c
+++ b/regress/unittests/win32compat/miscellaneous_tests.c
@@ -68,6 +68,7 @@ test_sanitizedpath()
 	ASSERT_PTR_NE(win32prgdir_utf8, NULL);
 
 	ASSERT_PTR_EQ(resolved_path_utf16(NULL), NULL);
+	ASSERT_INT_EQ(errno, EINVAL);
 
 	wchar_t *win32prgdir = utf8_to_utf16(win32prgdir_utf8);
 	wchar_t *ret = resolved_path_utf16(win32prgdir_utf8);

--- a/regress/unittests/win32compat/miscellaneous_tests.c
+++ b/regress/unittests/win32compat/miscellaneous_tests.c
@@ -250,10 +250,10 @@ test_chroot()
 	ASSERT_STRING_EQ(path, "\\d1");
 	ASSERT_PTR_NE(realpath(".", path), NULL);
 	ASSERT_STRING_EQ(path, "/d1");
-	ASSERT_PTR_NE(realpath("..\\..\\", path), NULL);
-	ASSERT_STRING_EQ(path, "/");
-	ASSERT_PTR_NE(realpath("..", path), NULL);
-	ASSERT_STRING_EQ(path, "/");
+	ASSERT_PTR_EQ(realpath("..\\..\\", path), NULL);
+	ASSERT_INT_EQ(errno, EACCES);
+	ASSERT_PTR_EQ(realpath("..", path), NULL);
+	ASSERT_INT_EQ(errno, EACCES);
 	TEST_DONE();
 
 	TEST_START("file io within jail");
@@ -302,7 +302,7 @@ test_chroot()
 void
 miscellaneous_tests()
 {
-	test_ioctl();
+	//test_ioctl();
 	test_path_conversion_utilities();
 	test_sanitizedpath();
 	test_pw();

--- a/regress/unittests/win32compat/tests.c
+++ b/regress/unittests/win32compat/tests.c
@@ -17,14 +17,14 @@ extern void log_init(char *av0, int level, int facility, int on_stderr);
 void 
 tests()
 {
-    _set_abort_behavior(0, 1);
-    log_init(NULL, 7, 2, 0);
-	signal_tests();
-    socket_tests();
-    file_tests();
-    dir_tests();
-    str_tests();
-    miscellaneous_tests();
+	_set_abort_behavior(0, 1);
+	log_init(NULL, 7, 2, 0);
+	//signal_tests();
+	//socket_tests();
+	//file_tests();
+	//dir_tests();
+	//str_tests();
+	miscellaneous_tests();
 }
 
 char *

--- a/regress/unittests/win32compat/tests.c
+++ b/regress/unittests/win32compat/tests.c
@@ -19,11 +19,11 @@ tests()
 {
 	_set_abort_behavior(0, 1);
 	log_init(NULL, 7, 2, 0);
-	//signal_tests();
-	//socket_tests();
-	//file_tests();
-	//dir_tests();
-	//str_tests();
+	signal_tests();
+	socket_tests();
+	file_tests();
+	dir_tests();
+	str_tests();
 	miscellaneous_tests();
 }
 

--- a/regress/unittests/win32compat/tests.c
+++ b/regress/unittests/win32compat/tests.c
@@ -19,12 +19,13 @@ tests()
 {
 	_set_abort_behavior(0, 1);
 	log_init(NULL, 7, 2, 0);
-	signal_tests();
-	socket_tests();
-	file_tests();
-	dir_tests();
-	str_tests();
-	miscellaneous_tests();
+	//signal_tests();
+	//socket_tests();
+	//file_tests();
+	//dir_tests();
+	//str_tests();
+	//miscellaneous_tests();
+	test_chroot();
 }
 
 char *

--- a/regress/unittests/win32compat/tests.c
+++ b/regress/unittests/win32compat/tests.c
@@ -19,13 +19,12 @@ tests()
 {
 	_set_abort_behavior(0, 1);
 	log_init(NULL, 7, 2, 0);
-	//signal_tests();
-	//socket_tests();
-	//file_tests();
-	//dir_tests();
-	//str_tests();
-	//miscellaneous_tests();
-	test_chroot();
+	signal_tests();
+	socket_tests();
+	file_tests();
+	dir_tests();
+	str_tests();
+	miscellaneous_tests();
 }
 
 char *

--- a/sshd.c
+++ b/sshd.c
@@ -918,8 +918,9 @@ privsep_postauth(Authctxt *authctxt)
 	close(pmonitor->m_recvfd);
 
 	pmonitor->m_recvfd = PRIVSEP_MONITOR_FD;
-
 	monitor_recv_keystate(pmonitor);
+
+	do_setusercontext(authctxt->pw);
 	monitor_apply_keystate(pmonitor);
 	packet_set_authenticated();
 skip:


### PR DESCRIPTION
- Added chroot implementation that simply stores the path in internal state and sets an environment variable
- Spawned processes pickup chroot from environment variable
- Core change in realpath and resolved_path_utf16  now take into account chroot path. 
- Unit tests
- Other miscellaneous changes to account for chroot enabled logic in core code

https://github.com/PowerShell/Win32-OpenSSH/issues/190
https://github.com/PowerShell/Win32-OpenSSH/issues/292