### PR TITLE
Buffer overflow in Scp

### DIFF
--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -121,7 +121,11 @@ WARNING: Following changes will be made to OpenSSH configuration
         $con = (Get-Content $targetsshdConfig | Out-String).Replace("#SyslogFacility AUTH","SyslogFacility LOCAL0")
         Set-Content -Path $targetsshdConfig -Value "$con" -Force    
     }
-    
+    $sshdSvc = Get-service ssh-agent
+    if($sshdSvc.StartType -eq [System.ServiceProcess.ServiceStartMode]::Disabled)
+    {
+        Set-service ssh-agent -StartupType Manual
+    }
     Start-Service ssh-agent
 
     #copy sshtest keys

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -102,7 +102,7 @@ Describe "Setup Tests" -Tags "Setup" {
                 $identities = @($systemSid, $adminsSid, $trustedInstallerSid, $allApplicationPackagesSid, $allRestrictedApplicationPackagesSid, $usersSid)
             }
 
-            $identities | % {                
+            $identities | % {
                 $myACL.Access.IdentityReference -contains (Get-UserAccount -UserSid $_) | Should Be $true
             }
 

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -102,8 +102,8 @@ Describe "Setup Tests" -Tags "Setup" {
                 $identities = @($systemSid, $adminsSid, $trustedInstallerSid, $allApplicationPackagesSid, $allRestrictedApplicationPackagesSid, $usersSid)
             }
 
-            $identities | % {
-                (Get-UserAccount -UserSid $_) | Should BeIn $myACL.Access.IdentityReference
+            $identities | % {                
+                $myACL.Access.IdentityReference -contains (Get-UserAccount -UserSid $_) | Should Be $true
             }
 
             foreach ($a in $myACL.Access) {
@@ -114,7 +114,7 @@ Describe "Setup Tests" -Tags "Setup" {
                     $id = Get-UserSID -User $idRefShortValue                                      
                 }
 
-                $id | Should BeIn $identities
+                $identities -contains $id | Should be $true
 
                 switch ($id)
                 {
@@ -300,32 +300,37 @@ Describe "Setup Tests" -Tags "Setup" {
         }
 
         It "$tC.$tI - Validate Registry key ssh-agent\ObjectName" {
-            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent") -Name "ObjectName"            
+            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent") -Name "ObjectName"
             $p | Should Be "LocalSystem"
         }        
 
         It "$tC.$tI - Validate Registry key ssh-agent\Start" {
-            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent") -Name "Start"            
-            $p | Should Be 3
+            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent") -Name "Start"  
+            if($windowsInBox) {
+                $p | Should Be 4
+            }
+            else {
+                $p | Should Be 3
+            }
         }
 
         It "$tC.$tI - Validate Registry key ssh-agent\Type" {
-            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent") -Name "Type"            
+            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent") -Name "Type"
             $p | Should Be 16
         }        
 
         It "$tC.$tI - Validate Registry key to ssh-agent\Security\Security" { 
-            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent\Security") -Name Security            
+            $p = Get-ItemPropertyValue (Join-Path $servicePath "ssh-agent\Security") -Name Security
             $p.Gettype() | Should Be byte[]
         }        
 
         It "$tC.$tI - Validate Registry key sshd\Description" {
-            $p = Get-ItemPropertyValue (Join-Path $servicePath "sshd") -Name "Description"            
+            $p = Get-ItemPropertyValue (Join-Path $servicePath "sshd") -Name "Description"
             $p | Should not Be $null
         }
 
         It "$tC.$tI - Validate Registry key sshd\ErrorControl" {
-            $p = Get-ItemPropertyValue (Join-Path $servicePath "sshd") -Name "ErrorControl"            
+            $p = Get-ItemPropertyValue (Join-Path $servicePath "sshd") -Name "ErrorControl"
             $p | Should Be 1
         }
 
@@ -355,12 +360,15 @@ Describe "Setup Tests" -Tags "Setup" {
         }
         It "$tC.$tI - Validate Registry openssh\agent entry" {
             $agentPath = Join-Path $opensshRegPath "Agent"
-            if(-not (Test-Path $agentPath -PathType Container))
+            if(Test-Path $agentPath -PathType Container)
+            {
+                ValidateRegistryACL -RegPath $agentPath -IdAcls $opensshACLs
+            }
+            elseif((-not $windowsInBox) -or ((Get-Service ssh-agent).StartType -ne ([System.ServiceProcess.ServiceStartMode]::Disabled)))
             {
                 Start-Service ssh-agent
-            }
-
-            ValidateRegistryACL -RegPath $agentPath -IdAcls $opensshACLs
+                ValidateRegistryACL -RegPath $agentPath -IdAcls $opensshACLs
+            }                            
         }
     }
 
@@ -373,7 +381,12 @@ Describe "Setup Tests" -Tags "Setup" {
 
         It "$tC.$tI - Validate properties of ssh-agent service" {            
             $sshdSvc = Get-service ssh-agent
-            $sshdSvc.StartType | Should Be ([System.ServiceProcess.ServiceStartMode]::Manual)
+            if($windowsInBox) {
+                $sshdSvc.StartType | Should Be ([System.ServiceProcess.ServiceStartMode]::Disabled)
+            }
+            else {
+                $sshdSvc.StartType | Should Be ([System.ServiceProcess.ServiceStartMode]::Manual)
+            }
             $sshdSvc.ServiceType | Should Be ([System.ServiceProcess.ServiceType]::Win32OwnProcess)
             $sshdSvc.ServiceName | Should Be "ssh-agent"
             $sshdSvc.DisplayName | Should BeLike "OpenSSH*"
@@ -407,11 +420,11 @@ Describe "Setup Tests" -Tags "Setup" {
             $a = sc.exe qprivs sshd 256
             $p = $a | % { if($_ -match "Se[\w]+Privilege" ) {$start = $_.IndexOf("Se");$_.Substring($start, $_.length-$start)}}
             $expected | % {
-                $_ | Should BeIn $p
+                $p -contains $_ | Should be $true
             }
 
             $p | % {
-                $_ | Should BeIn $expected
+                $expected -contains $_ | Should be $true
             }
         }
 
@@ -426,10 +439,10 @@ Describe "Setup Tests" -Tags "Setup" {
             $actual_dacl_aces = $dacl_aces | ? { -not [string]::IsNullOrWhiteSpace($_) }
 
             $expected_dacl_aces | % {
-                $_ | Should BeIn $actual_dacl_aces
+                $actual_dacl_aces -contains $_ | Should be $true 
             }
             $actual_dacl_aces | % {
-                $_ | Should BeIn $expected_dacl_aces
+                $expected_dacl_aces -contains $_ | Should be $true
             }
 
             <# ignore sacl for now
@@ -449,10 +462,10 @@ Describe "Setup Tests" -Tags "Setup" {
             $actual_dacl_aces = $dacl_aces | ? { -not [string]::IsNullOrWhiteSpace($_) }
 
             $expected_dacl_aces | % {
-                $_ | Should BeIn $actual_dacl_aces
+                $actual_dacl_aces -contains $_ | Should be $true
             }
             $actual_dacl_aces | % {
-                $_ | Should BeIn $expected_dacl_aces
+                $expected_dacl_aces -contains $_ | Should be $true
             }
 
             <# ignore sacl for now

--- a/scp.c
+++ b/scp.c
@@ -214,8 +214,9 @@ do_local_cmd(arglist *a)
 		cmd = xmalloc(cmdlen);
 		cmd[0] = '\0';
 		for (i = 0; i < a->num; i++) {
-			strcat(cmd, a->list[i]);
-			strcat(cmd, " ");
+			if(i != 0)
+				strcat_s(cmd, cmdlen, " ");
+			strcat_s(cmd, cmdlen, a->list[i]);
 		}
 		if (system(cmd))
 			return -1; 


### PR DESCRIPTION
1. Fix buffer overflow in Scp. https://github.com/PowerShell/Win32-OpenSSH/issues/1156 (There was no space for null character in the destination string)
2. Update setup tests to take into account the service startup type in windows inbox.
3. update the validation steps (Should Bein does not work in the pester module in windows inbox)