### PR TITLE
Remove None/Domain Users Group Filter

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1273,17 +1273,12 @@ getusergroups(const char *user, int *ngroups)
 			!IsValidSid(group_buf->Groups[i].Sid))
 			continue;
 
-		/* only bother with groups that are builtin or classic domain/local groups 
-		 * also ignore domain users and builtin users since these will be meaningless 
-		 * since they do not resolve properly on workgroup computers; these would 
-		 * never meaningfully be used in the server configuration */
+		/* only bother with groups that are builtin or classic domain/local groups */
 		SID * sid = group_buf->Groups[i].Sid;
 		DWORD sub = sid->SubAuthority[0];
-		DWORD rid = sid->SubAuthority[sid->SubAuthorityCount - 1]; 
 		SID_IDENTIFIER_AUTHORITY nt_authority = SECURITY_NT_AUTHORITY;
 		if (memcmp(&nt_authority, GetSidIdentifierAuthority(sid), sizeof(SID_IDENTIFIER_AUTHORITY)) == 0 && (
-			sub == SECURITY_NT_NON_UNIQUE || sub == SECURITY_BUILTIN_DOMAIN_RID) &&
-			rid != DOMAIN_GROUP_RID_USERS && rid != DOMAIN_ALIAS_RID_USERS) {
+			sub == SECURITY_NT_NON_UNIQUE || sub == SECURITY_BUILTIN_DOMAIN_RID)) {
 
 			/* lookup the account name for this sid */
 			wchar_t name[GNLEN + 1];

--- a/regress/pesterTests/SSHDConfig.tests.ps1
+++ b/regress/pesterTests/SSHDConfig.tests.ps1
@@ -228,19 +228,6 @@ Describe "Tests of sshd_config" -Tags "CI" {
 
         }
 
-        It "$tC.$tI-User with full name in the list of AllowUsers but not in any AllowGroups"  -skip:$skip {
-           #Run
-           Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 
-
-           Add-LocalUser -UserName $allowUser4 -Password $password
-
-           ssh -p $port -E $sshlog -o "UserKnownHostsFile $testknownhosts" $allowUser4@$server echo 1234
-           $LASTEXITCODE | Should Not Be 0
-           Stop-SSHDTestDaemon
-           $sshdlog | Should Contain "not allowed because not in any group"
-           
-        }
-
         It "$tC.$tI-User with full name in the list of DenyUsers"  -skip:$skip {
            #Run
            Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdConfigPath -E $sshdlog" 


### PR DESCRIPTION
- Removed logic that was excluding the group membership SID that matched 'None' on workgroup computers or 'Domain Users' on domain systems.
- Removed test that was checking that AllowGroups failure if user was not in any group at all.  This is no longer testable since user will always be a member of at least one group.