### PR TITLE
Add double quotes around no-pty cmd, fix backspace issue

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1868,14 +1868,10 @@ do {					\
 		else
 			CMDLINE_APPEND(p, " -c ");
 
-		/* bash type shells require " decoration around command*/
-		if (shell_type == SH_BASH)
-			CMDLINE_APPEND(p, "\"");
-
+		/* Add double quotes around command */
+		CMDLINE_APPEND(p, "\"");
 		CMDLINE_APPEND(p, command);
-
-		if (shell_type == SH_BASH)
-			CMDLINE_APPEND(p, "\"");
+		CMDLINE_APPEND(p, "\"");
 	}
 	*p = '\0';
 	ret = cmdline;

--- a/contrib/win32/win32compat/signal.c
+++ b/contrib/win32/win32compat/signal.c
@@ -107,7 +107,7 @@ static VOID CALLBACK
 sigwinch_APCProc(_In_ ULONG_PTR dwParam)
 {
 	debug5("SIGTERM APCProc()");
-	sigaddset(&pending_signals, W32_SIGWINCH);
+	sigaddset(&pending_signals, SIGWINCH);
 }
 
 void

--- a/contrib/win32/win32compat/tncon.h
+++ b/contrib/win32/win32compat/tncon.h
@@ -56,7 +56,7 @@
 #define SHIFT_TAB_KEY               "\x1b[~"
 #define SHIFT_ALT_Q                 "\x1b?"
 #define ESCAPE_KEY		    "\x1b"
-#define BACKSPACE_KEY               "\b"
+#define BACKSPACE_KEY               "\x7f"
 
 // VT100 Function Key's
 #define VT100_PF1_KEY               "\x1bO2"


### PR DESCRIPTION
1) Add double quotes around no-pty cmd.
2) Fix backspace issue (https://github.com/PowerShell/Win32-OpenSSH/issues/1190)