### PR TITLE
Use Implicit User Principal Name If Explicit Does Not Exist

### DIFF
--- a/auth-passwd.c
+++ b/auth-passwd.c
@@ -258,18 +258,16 @@ sys_auth_passwd(struct ssh *ssh, const char *password)
 	/* translate to domain user if format contains a backslash */
 	wchar_t * backslash = wcschr(user_utf16, L'\\');
 	if (backslash != NULL) {
+
 		/* attempt to format into upn format as this is preferred for login */
-		if (pTranslateNameW(user_utf16, NameSamCompatible, NameUserPrincipal, domain_upn, &domain_upn_len) != 0) {
-			debug3("%s: Successfully discovered principal name: '%ls'=>'%ls'",
-				__FUNCTION__, user_utf16, domain_upn);
+		if (lookup_principal_name(user_utf16, domain_upn) == 0) {
 			unam_utf16 = domain_upn;
 			udom_utf16 = NULL;
 		}
 
-		/* user likely does not have upn so just use SamCompatibleName */
+		/* could not discover upn so just use netbios for the domain parameter and
+		 * the sam account name for the user name */
 		else {
-			debug3("%s: Unable to discover principal name for user '%ls': %d",
-				__FUNCTION__, user_utf16, GetLastError());
 			*backslash = '\0';
 			unam_utf16 = backslash + 1;
 			udom_utf16 = user_utf16;

--- a/contrib/win32/win32compat/misc_internal.h
+++ b/contrib/win32/win32compat/misc_internal.h
@@ -56,3 +56,4 @@ PSID get_sid(const char*);
 int am_system();
 char* build_session_commandline(const char *, const char *, const char *, int );
 char* get_custom_lsa_package();
+int lookup_principal_name(const wchar_t * sam_account_name, wchar_t * user_principal_name);

--- a/contrib/win32/win32compat/win32_usertoken_utils.c
+++ b/contrib/win32/win32compat/win32_usertoken_utils.c
@@ -133,19 +133,10 @@ generate_s4u_user_token(wchar_t* user_cpn, int impersonation) {
 
 	if (domain_user) {
 
-		/* assemble the path to the name translation library */
+		/* lookup the user principal name for the account */
 		WCHAR domain_upn[MAX_UPN_LEN + 1];
-		ULONG domain_upn_len = ARRAYSIZE(domain_upn);
-		if (pTranslateNameW(user_cpn, NameSamCompatible, NameUserPrincipal, domain_upn, &domain_upn_len) == 0) {
-
-			/* upn lookup failed so resort to attempting samcompatiblename */
-			debug3("%s: Unable to discover principal name for user '%ls': %d",
-				__FUNCTION__, user_cpn, GetLastError());
-			wcscpy_s(domain_upn, ARRAYSIZE(domain_upn), user_cpn);
-		}
-		else
-			debug3("%s: Successfully discovered principal name: '%ls'=>'%ls'", __FUNCTION__, user_cpn, domain_upn);
-
+		lookup_principal_name(user_cpn, domain_upn);
+		
 		KERB_S4U_LOGON *s4u_logon;
 		logon_info_size = sizeof(KERB_S4U_LOGON);
 
@@ -713,6 +704,39 @@ get_custom_lsa_package()
 
 	s_processed = 1;
 	return s_lsa_auth_pkg;
+}
+
+int lookup_principal_name(const wchar_t * sam_account_name, wchar_t * user_principal_name)
+{
+	wchar_t domain_upn[MAX_UPN_LEN + 1];
+	DWORD domain_upn_len = ARRAYSIZE(domain_upn);
+	DWORD lookup_error = 0;
+
+	/* try explicit lookup */
+	if (pTranslateNameW(sam_account_name, NameSamCompatible, NameUserPrincipal, domain_upn, &domain_upn_len) != 0) {
+		wcscpy_s(user_principal_name, MAX_UPN_LEN + 1, domain_upn);
+		debug3("%s: Successfully discovered explicit principal name: '%ls'=>'%ls'",
+			__FUNCTION__, sam_account_name, user_principal_name);
+		return 0;
+	}
+
+	/* try implicit lookup */
+	lookup_error = GetLastError();
+	domain_upn_len = ARRAYSIZE(domain_upn);
+	if (pTranslateNameW(sam_account_name, NameSamCompatible, NameCanonical, domain_upn, &domain_upn_len) != 0) {
+		wcscpy_s(user_principal_name, MAX_UPN_LEN + 1, wcschr(sam_account_name, L'\\') + 1);
+		wcscat_s(user_principal_name, MAX_UPN_LEN + 1, L"@");
+		wcsncat_s(user_principal_name, MAX_UPN_LEN + 1, domain_upn, wcschr(domain_upn, L'/') - domain_upn);
+		debug3("%s: Successfully discovered implicit principal name: '%ls'=>'%ls'",
+			__FUNCTION__, sam_account_name, user_principal_name);
+		return 0;
+	}
+
+	/* report error and copy the sam account name into the buffer */
+	error("%s: User principal name lookup failed for user '%ls' (explicit: %d, implicit: %d)",
+		__FUNCTION__, sam_account_name, lookup_error, GetLastError());
+	wcscpy_s(user_principal_name, MAX_UPN_LEN + 1, sam_account_name);
+	return -1;
 }
 
 #pragma warning(pop)


### PR DESCRIPTION
- Modified user principal name lookup to default to the implicit form (SamAccountName@DnsDomainName) if no explicit user principal name attribute is found on the account.