### PR TITLE
Fix of issues 1139

### DIFF
--- a/contrib/win32/openssh/GetLibreSSL.ps1
+++ b/contrib/win32/openssh/GetLibreSSL.ps1
@@ -1,32 +1,41 @@
 ﻿param (
         [string]$sourceUrl = "https://github.com/PowerShell/libressl/releases/latest/",
         [string]$zipDir,
-        [string]$destPath)
+        [string]$destDir,
+        [switch]$override
+        )
 
 If ($PSVersiontable.PSVersion.Major -le 2) {$PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path}
-#workaround that $PSScriptRoot is not support on ps version 2
+# Workaround that $PSScriptRoot is not support on ps version 2
 if([string]::IsNullOrEmpty($zipDir))
 {
     $zipDir = $PSScriptRoot
 }
-if([string]::IsNullOrEmpty($destPath))
+
+if([string]::IsNullOrEmpty($destDir))
 {
-    $destPath = $PSScriptRoot
+    $destDir = $PSScriptRoot
 }
-if (Test-Path (Join-Path $destPath "LibreSSL"))
+
+if($override)
+{
+    Remove-Item (join-path $destDir "LibreSSL") -Recurse -Force -ErrorAction SilentlyContinue
+}
+elseif (Test-Path (Join-Path $destDir "LibreSSL"))
 {
     return
 }
+
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor `
                                                   [Net.SecurityProtocolType]::Tls11 -bor `
                                                   [Net.SecurityProtocolType]::Tls
     
     $request = [System.Net.WebRequest]::Create($sourceUrl)
     $request.AllowAutoRedirect = $false
-    $request.Timeout = 30000; #30 sec
-    $response=$request.GetResponse()
-    $release_url=$([String]$response.GetResponseHeader("Location")).Replace('tag','download') + '/LibreSSL.zip' 
-    $zip_path=Join-Path $zipDir "libressl.zip"   
+    $request.Timeout = 60000; #30 sec
+    $response = $request.GetResponse()
+    $release_url = $([String]$response.GetResponseHeader("Location")).Replace('tag','download') + '/LibreSSL.zip' 
+    $zip_path = Join-Path $zipDir "libressl.zip"
 
     #download libressl latest release binaries
     Remove-Item $zip_path -Force -ErrorAction SilentlyContinue
@@ -35,10 +44,12 @@ if (Test-Path (Join-Path $destPath "LibreSSL"))
     {
         throw "failed to download ssl zip file"
     }
+    
     #copy libressl
-    Expand-Archive -Path $zip_path -DestinationPath $destpath -Force -ErrorAction SilentlyContinue -ErrorVariable e
+    Expand-Archive -Path $zip_path -DestinationPath $destDir -Force -ErrorAction SilentlyContinue -ErrorVariable e
     if($e -ne $null)
     {
         throw "Error when expand zip file"
     }
+    
     Remove-Item $zip_path -Force -ErrorAction SilentlyContinue

--- a/contrib/win32/openssh/GetLibreSSL.ps1
+++ b/contrib/win32/openssh/GetLibreSSL.ps1
@@ -21,23 +21,23 @@ if($override)
 {
     Remove-Item (join-path $destDir "LibreSSL") -Recurse -Force -ErrorAction SilentlyContinue
 }
-elseif (Test-Path (Join-Path $destDir "LibreSSL"))
+elseif (Test-Path (Join-Path $destDir "LibreSSL") -PathType Container)
 {
     return
 }
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor `
-                                                  [Net.SecurityProtocolType]::Tls11 -bor `
-                                                  [Net.SecurityProtocolType]::Tls
+                                              [Net.SecurityProtocolType]::Tls11 -bor `
+                                              [Net.SecurityProtocolType]::Tls
     
     $request = [System.Net.WebRequest]::Create($sourceUrl)
     $request.AllowAutoRedirect = $false
-    $request.Timeout = 60000; #30 sec
+    $request.Timeout = 60000; # 1 mins for the download to complete
     $response = $request.GetResponse()
     $release_url = $([String]$response.GetResponseHeader("Location")).Replace('tag','download') + '/LibreSSL.zip' 
     $zip_path = Join-Path $zipDir "libressl.zip"
 
-    #download libressl latest release binaries
+    # Download libressl latest release binaries
     Remove-Item $zip_path -Force -ErrorAction SilentlyContinue
     (New-Object System.Net.WebClient).DownloadFile($release_url, $zip_path)
     if(-not (Test-Path $zip_path))
@@ -45,7 +45,7 @@ elseif (Test-Path (Join-Path $destDir "LibreSSL"))
         throw "failed to download ssl zip file"
     }
     
-    #copy libressl
+    # Expand the zip file
     Expand-Archive -Path $zip_path -DestinationPath $destDir -Force -ErrorAction SilentlyContinue -ErrorVariable e
     if($e -ne $null)
     {

--- a/contrib/win32/openssh/OpenSSHBuildHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHBuildHelper.psm1
@@ -690,9 +690,13 @@ function Get-BuildLogFile
                 
         [ValidateSet('Debug', 'Release')]
         [string]$Configuration = "Release"
-        
-    )    
-    return Join-Path -Path $root -ChildPath "contrib\win32\openssh\OpenSSH$($Configuration)$($NativeHostArch).log"
+    )
+    if($root -ieq $PSScriptRoot)
+    {
+        return Join-Path -Path $PSScriptRoot -ChildPath "OpenSSH$($Configuration)$($NativeHostArch).log"
+    } else {
+        return Join-Path -Path $root -ChildPath "contrib\win32\openssh\OpenSSH$($Configuration)$($NativeHostArch).log"
+    }
 }
 
 function Get-SolutionFile
@@ -701,9 +705,14 @@ function Get-SolutionFile
     (
         [Parameter(Mandatory=$true)]
         [ValidateNotNull()]
-        [System.IO.DirectoryInfo] $root        
+        [System.IO.DirectoryInfo] $root
     )    
-    return Join-Path -Path $root -ChildPath "contrib\win32\openssh\Win32-OpenSSH.sln"    
+    if($root -ieq $PSScriptRoot)
+    {
+        return Join-Path -Path $PSScriptRoot -ChildPath "Win32-OpenSSH.sln"
+    } else {
+        return Join-Path -Path $root -ChildPath "contrib\win32\openssh\Win32-OpenSSH.sln"
+    }
 }
 
 

--- a/contrib/win32/openssh/config.vcxproj
+++ b/contrib/win32/openssh/config.vcxproj
@@ -187,7 +187,7 @@
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>
@@ -221,7 +221,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>
@@ -255,7 +255,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>
@@ -289,7 +289,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>
@@ -327,7 +327,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>
@@ -365,7 +365,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>
@@ -403,7 +403,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>
@@ -441,7 +441,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
-powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Generate crtheaders.h and config.h; copy libressl</Message>

--- a/contrib/win32/openssh/config.vcxproj
+++ b/contrib/win32/openssh/config.vcxproj
@@ -190,7 +190,7 @@
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -224,7 +224,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -258,7 +258,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -292,7 +292,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -330,7 +330,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -368,7 +368,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -406,7 +406,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -444,7 +444,7 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
 powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)GetLibreSSL.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
+      <Message>Generate crtheaders.h and config.h; fetch libressl sdk</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"

--- a/contrib/win32/openssh/config.vcxproj
+++ b/contrib/win32/openssh/config.vcxproj
@@ -186,10 +186,11 @@
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-x86-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -219,10 +220,11 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-x64-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -252,10 +254,11 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-arm64-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -285,10 +288,11 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-arm-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -322,10 +326,11 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-x86-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -359,10 +364,11 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-x64-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -396,10 +402,11 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-arm64-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"
@@ -433,10 +440,11 @@ copy /Y "$(SolutionDir)openssh-events.man" "$(OutDir)"</Command>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(LibreSSL-arm-Path);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"</Command>
+      <Command>powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)config.ps1" -Config_h_vs "$(SolutionDir)config.h.vs" -Config_h "$(OpenSSH-Src-Path)config.h" -VCIncludePath "$(VC_IncludePath)" -OutCRTHeader "$(OpenSSH-Src-Path)contrib\win32\win32compat\inc\crtheaders.h"
+powershell.exe -Executionpolicy Bypass -File "$(SolutionDir)copyssl.ps1"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Generate crtheaders.h and config.h</Message>
+      <Message>Generate crtheaders.h and config.h; copy libressl</Message>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)install-ssh*ps1" "$(OutDir)"

--- a/contrib/win32/openssh/copyssl.ps1
+++ b/contrib/win32/openssh/copyssl.ps1
@@ -1,0 +1,44 @@
+﻿param (
+        [string]$sourceUrl = "https://github.com/PowerShell/libressl/releases/latest/",
+        [string]$zipDir,
+        [string]$destPath)
+
+If ($PSVersiontable.PSVersion.Major -le 2) {$PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path}
+#workaround that $PSScriptRoot is not support on ps version 2
+if([string]::IsNullOrEmpty($zipDir))
+{
+    $zipDir = $PSScriptRoot
+}
+if([string]::IsNullOrEmpty($destPath))
+{
+    $destPath = $PSScriptRoot
+}
+if (Test-Path (Join-Path $destPath "LibreSSL"))
+{
+    return
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor `
+                                                  [Net.SecurityProtocolType]::Tls11 -bor `
+                                                  [Net.SecurityProtocolType]::Tls
+    
+    $request = [System.Net.WebRequest]::Create($sourceUrl)
+    $request.AllowAutoRedirect = $false
+    $request.Timeout = 30000; #30 sec
+    $response=$request.GetResponse()
+    $release_url=$([String]$response.GetResponseHeader("Location")).Replace('tag','download') + '/LibreSSL.zip' 
+    $zip_path=Join-Path $zipDir "libressl.zip"   
+
+    #download libressl latest release binaries
+    Remove-Item $zip_path -Force -ErrorAction SilentlyContinue
+    (New-Object System.Net.WebClient).DownloadFile($release_url, $zip_path)
+    if(-not (Test-Path $zip_path))
+    {
+        throw "failed to download ssl zip file"
+    }
+    #copy libressl
+    Expand-Archive -Path $zip_path -DestinationPath $destpath -Force -ErrorAction SilentlyContinue -ErrorVariable e
+    if($e -ne $null)
+    {
+        throw "Error when expand zip file"
+    }
+    Remove-Item $zip_path -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Fix of https://github.com/PowerShell/Win32-OpenSSH/issues/1139.
Now user should be able to build use .sln file without manual steps
1. Added prebuildevent to copy libressl
2. When there is no '.git' in the environment, $psscriptroot is the default location to look for the solution and log file