### PR TITLE
Revert the isolation changes on Admin and Operational Channels

### DIFF
--- a/contrib/win32/openssh/Openssh-events.man
+++ b/contrib/win32/openssh/Openssh-events.man
@@ -20,13 +20,9 @@
 					</level>
 				</levels>
 				<channels>
-					<channel
-						access="O:BAG:BAD:(A;;0x2;;;BU)(A;;0x2;;;S-1-15-2-1)(A;;0x2;;;S-1-15-3-1024-3153509613-960666767-3724611135-2725662640-12138253-543910227-1950414635-4190290187)(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)"
-						isolation="Custom" name="OpenSSH/Admin" chid="OpenSSH/Admin" symbol="OpenSSH_Admin" type="Admin" enabled="true">
+					<channel name="OpenSSH/Admin" chid="OpenSSH/Admin" symbol="OpenSSH_Admin" type="Admin" enabled="true">
 					</channel>
-					<channel
-						access="O:BAG:BAD:(A;;0x2;;;BU)(A;;0x2;;;S-1-15-2-1)(A;;0x2;;;S-1-15-3-1024-3153509613-960666767-3724611135-2725662640-12138253-543910227-1950414635-4190290187)(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)"
-						isolation="Custom" name="OpenSSH/Operational" chid="OpenSSH/Operational" symbol="OpenSSH_Operational" type="Operational" enabled="true">
+					<channel name="OpenSSH/Operational" chid="OpenSSH/Operational" symbol="OpenSSH_Operational" type="Operational" enabled="true">
 					</channel>
 					<channel
 						access="O:BAG:BAD:(A;;0x2;;;BU)(A;;0x2;;;S-1-15-2-1)(A;;0x2;;;S-1-15-3-1024-3153509613-960666767-3724611135-2725662640-12138253-543910227-1950414635-4190290187)(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)"


### PR DESCRIPTION
Revert the isolation changes introduced by [this commit](https://github.com/PowerShell/openssh-portable/commit/48e0cdbd5f2e0b65d2e557cac6b036d08880d1f6) on Admin and Operational Channels since they are enable by default and add 2 more independent autologgers on the system.