### PR TITLE
Fix Console handle leaks

### DIFF
--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -135,7 +135,7 @@ ConEnterRawMode()
 
 	if (!GetConsoleMode(GetConsoleInputHandle(), &stdin_dwSavedAttributes)) {
 		dwRet = GetLastError();
-		error("GetConsoleMode on console input handle failed with %d\n", dwRet);
+		error("GetConsoleMode on console input handle failed with %d", dwRet);
 		return;
 	}
 
@@ -148,13 +148,13 @@ ConEnterRawMode()
 
 	if (!SetConsoleMode(GetConsoleInputHandle(), dwAttributes)) { /* Windows NT */
 		dwRet = GetLastError();
-		error("SetConsoleMode on STD_INPUT_HANDLE failed with %d\n", dwRet);
+		error("SetConsoleMode on STD_INPUT_HANDLE failed with %d", dwRet);
 		return;
 	}
 
 	if (!GetConsoleMode(GetConsoleOutputHandle(), &stdout_dwSavedAttributes)) {
 		dwRet = GetLastError();
-		error("GetConsoleMode on GetConsoleOutputHandle() failed with %d\n", dwRet);
+		error("GetConsoleMode on GetConsoleOutputHandle() failed with %d", dwRet);
 		return;
 	}
 

--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -84,7 +84,7 @@ GetConsoleOutputHandle()
 	static HANDLE	s_hOutputConsole = INVALID_HANDLE_VALUE;
 
 	if (s_hOutputConsole != INVALID_HANDLE_VALUE)
-		s_hOutputConsole;
+		return s_hOutputConsole;
 
 	sa.nLength = sizeof(SECURITY_ATTRIBUTES);
 	sa.lpSecurityDescriptor = NULL;
@@ -107,7 +107,7 @@ GetConsoleInputHandle()
 	static HANDLE	s_hInputConsole = INVALID_HANDLE_VALUE;
 
 	if (s_hInputConsole != INVALID_HANDLE_VALUE)
-		s_hInputConsole;
+		return s_hInputConsole;
 
 	sa.nLength = sizeof(SECURITY_ATTRIBUTES);
 	sa.lpSecurityDescriptor = NULL;

--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -91,12 +91,12 @@ ReadThread(_In_ LPVOID lpParameter)
 
 				DWORD dwAttributes;
 				if (!GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &dwAttributes))
-					error("GetConsoleMode on STD_INPUT_HANDLE failed with %d\n", GetLastError());
+					error("GetConsoleMode on STD_INPUT_HANDLE failed with %d", GetLastError());
 				
 				dwAttributes |= (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
 
 				if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), dwAttributes))
-					error("SetConsoleMode on STD_INPUT_HANDLE failed with %d\n", GetLastError());
+					error("SetConsoleMode on STD_INPUT_HANDLE failed with %d", GetLastError());
 			}
 
 			if (!ReadFile(WINHANDLE(pio), pio->read_details.buf,


### PR DESCRIPTION
Issue: Earlier change missed "return" calls that will end up ignoring singleton logic and re-running console handle generation logic multiple times, leaking previously created handles in the process. 

Fix: Add the missing "return" calls