### PR TITLE
Using the Y viewport for setting cursor correctly

### DIFF
--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -591,7 +591,7 @@ SendSetCursor(HANDLE hInput, int X, int Y)
 	int out = 0;
 	char formatted_output[255];
 
-	out = _snprintf_s(formatted_output, sizeof(formatted_output), _TRUNCATE, "\033[%d;%dH", Y, X);
+	out = _snprintf_s(formatted_output, sizeof(formatted_output), _TRUNCATE, "\033[%d;%dH", Y - ViewPortY, X);
 	if (out > 0 && bUseAnsiEmulation)
 		WriteFile(hInput, formatted_output, out, &wr, NULL);
 }


### PR DESCRIPTION
ANSI escape sequences are based on relative positions, while the X, Y in the code are absolute positions.
Without this fix, the sequence for updating the cursor position is incorrect if the viewport has scrolled.
Subtracting the viewport gives a correct relative cursor position. 

Steps to reproduce the bugs:

Open an ssh on a Windows machine without pseudoconsole.
Write commands until the screen scrolls at least one line.
Start a multiline string (by writing "+enter)
Write some lines in the string
Try to navigate using up/down arrows inside the string.

Before the fix, the cursor will be in an incorrect location. 