### PR TITLE
sshd_config - change default for GSSAPIAuthentication

### DIFF
--- a/contrib/win32/openssh/sshd_config
+++ b/contrib/win32/openssh/sshd_config
@@ -52,7 +52,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #PermitEmptyPasswords no
 
 # GSSAPI options
-GSSAPIAuthentication yes
+#GSSAPIAuthentication no
 
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes


### PR DESCRIPTION
As per https://man.openbsd.org/sshd_config, default for GSSAPIAuthentication is "no"