### PR TITLE
Workaround for PTY regressions

### DIFF
--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -266,7 +266,9 @@ syncio_close(struct w32_io* pio)
 		WaitForSingleObject(pio->write_overlapped.hEvent, INFINITE);
 	/* drain queued APCs */
 	SleepEx(0, TRUE);
-	CloseHandle(WINHANDLE(pio));
+	/* TODO - fix this, closing Console handles is interfering with TTY/PTY rendering */
+	if (FILETYPE(pio) != FILE_TYPE_CHAR)
+		CloseHandle(WINHANDLE(pio));
 	if (pio->read_details.buf)
 		free(pio->read_details.buf);
 	if (pio->write_details.buf)


### PR DESCRIPTION
Changes from https://github.com/PowerShell/openssh-portable/pull/353 enabled closing of previously duplicated Console handles - this is causing TTY rendering issues in ssh.exe. 

Added a workaround for now to skip closing Console handles. 