### PR TITLE
Account for dev/null being reported as a terminal handle

### DIFF
--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -90,13 +90,14 @@ ReadThread(_In_ LPVOID lpParameter)
 				isFirstTime = false;
 
 				DWORD dwAttributes;
-				if (!GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &dwAttributes))
-					error("GetConsoleMode on STD_INPUT_HANDLE failed with %d", GetLastError());
-				
-				dwAttributes |= (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+				/* open(dev/null) is showing up as FILE_TYPE_CHAR but is not a valid console handle */
+				if (GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &dwAttributes)) {
+					dwAttributes |= (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+					if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), dwAttributes))
+						debug2("SetConsoleMode on STD_INPUT_HANDLE failed with %d", GetLastError());
+				} else if (GetLastError() != ERROR_INVALID_HANDLE)
+					debug2("GetConsoleMode on STD_INPUT_HANDLE failed with %d", GetLastError());
 
-				if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), dwAttributes))
-					error("SetConsoleMode on STD_INPUT_HANDLE failed with %d", GetLastError());
 			}
 
 			if (!ReadFile(WINHANDLE(pio), pio->read_details.buf,


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/1330

Issue: open(dev/nul) returns a handle is passes isatty() test (i.e its being treated as a terminal handle by OS). This handle seems to work fine for as a console handle for console APIs, except when NUL is explicitly redirected. 
This works
```
ssh -n target hostname
```
but this hangs due to a deadlock from writing a log entry on a console API failure
```
ssh -n target hostname < NUL
```

Fix: Ignore console API failures when the handle is being reported as invalid. 