### PR TITLE
Fix issue with ProxyJump on Windows

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -1190,7 +1190,11 @@ main(int ac, char **av)
 		options.proxy_use_fdpass = 0;
 		snprintf(port_s, sizeof(port_s), "%d", options.jump_port);
 		xasprintf(&options.proxy_command,
+#ifdef WINDOWS
+		    "%s%s%s%s%s%s%s%s%s%s%.*s -W \"[%%h]:%%p\" %s",
+#else
 		    "%s%s%s%s%s%s%s%s%s%s%.*s -W '[%%h]:%%p' %s",
+#endif
 		    sshbin,
 		    /* Optional "-l user" argument if jump_user set */
 		    options.jump_user == NULL ? "" : " -l ",


### PR DESCRIPTION
ProxyJump commandline constructed by ssh following Unix commandline argument convention using single quotes. Added a #ifdef block to use double quotes for Windows. 
https://github.com/PowerShell/Win32-OpenSSH/issues/1172