### PR TITLE
Addressed Thread Hanging Issue

### DIFF
--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -243,6 +243,12 @@ syncio_initiate_write(struct w32_io* pio, DWORD num_bytes)
 	return 0;
 }
 
+static VOID CALLBACK
+InterruptThread(_In_ ULONG_PTR dwParam)
+{
+	_endthreadex(0);
+}
+
 /* close */
 int 
 syncio_close(struct w32_io* pio)
@@ -257,10 +263,12 @@ syncio_close(struct w32_io* pio)
 		1. For console - the read thread is blocked by the while loop on raw mode
 		2. Function ReadFile on Win7 machine dees not return when no content to read in non-interactive mode.
 		*/
-		if (FILETYPE(pio) == FILE_TYPE_CHAR && (IsWin7OrLess() || in_raw_mode))
-			TerminateThread(pio->read_overlapped.hEvent, 0);
-		else
-			WaitForSingleObject(pio->read_overlapped.hEvent, INFINITE);
+		if (FILETYPE(pio) == FILE_TYPE_CHAR && (IsWin7OrLess() || in_raw_mode)) {
+			QueueUserAPC(InterruptThread, pio->read_overlapped.hEvent, (ULONG_PTR)NULL);
+			CancelSynchronousIo(pio->read_overlapped.hEvent);
+		}
+
+		WaitForSingleObject(pio->read_overlapped.hEvent, INFINITE);
 	}
 	if (pio->write_details.pending)
 		WaitForSingleObject(pio->write_overlapped.hEvent, INFINITE);

--- a/contrib/win32/win32compat/tncon.c
+++ b/contrib/win32/win32compat/tncon.c
@@ -96,7 +96,7 @@ NetWriteString2(SOCKET sock, char* source, size_t len, int options)
 BOOL
 DataAvailable(HANDLE h)
 {
-	DWORD dwRet = WaitForSingleObject(h, INFINITE);
+	DWORD dwRet = WaitForSingleObjectEx(h, INFINITE, TRUE);
 	if (dwRet == WAIT_OBJECT_0)
 		return TRUE;
 	if (dwRet == WAIT_FAILED)


### PR DESCRIPTION
- Replaced TerminateThread() call with an interrupt routine to gracefully call _endthreadex(0).
- Resolves https://github.com/PowerShell/Win32-OpenSSH/issues/1338.