### PR TITLE
Addressed SCP Hanging Issue

### DIFF
--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -916,11 +916,18 @@ fileio_fdopen(struct w32_io* pio, const char *mode)
 {
 	wchar_t *file_path, *wmode = NULL;
 	FILE* ret = NULL;
+	DWORD type = 0;
 	
 	debug4("fdopen - io:%p", pio);
 
 	if ((wmode = utf8_to_utf16(mode)) == NULL)
 		goto cleanup;
+
+	/* for non-disk files, just return the descriptor */
+	type = GetFileType(pio->handle);
+	if (type != FILE_TYPE_DISK) {
+		return _fdopen(pio->table_index, mode);
+	}
 
 	file_path = get_final_path_by_handle(pio->handle);
 	if (!file_path) 


### PR DESCRIPTION
- Changed fileio_fdopen() to simply return the file descriptor for non-disk file types.
- Addresses issue where an error message in SCP (server side) was not being returned to the pipe which causes the process to hang.  Resolves: https://github.com/PowerShell/Win32-OpenSSH/issues/1345