### PR TITLE
Allow Console Output In UTF-8

### DIFF
--- a/contrib/win32/win32compat/win32-utf8.c
+++ b/contrib/win32/win32compat/win32-utf8.c
@@ -65,5 +65,7 @@ snmprintf(char *buf, size_t len, int *written, const char *fmt, ...)
 void
 msetlocale(void)
 {
+	// allow console output of unicode characters
+	SetConsoleOutputCP(CP_UTF8);
 }
 


### PR DESCRIPTION
- Address issue where console output does not display UTF-8 string properly.
- Resolves https://github.com/PowerShell/Win32-OpenSSH/issues/1225