### PR TITLE
Address Renaming Issue With exFAT File Systems

### DIFF
--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -98,6 +98,8 @@ errno_from_Win32Error(int win32_error)
 	case ERROR_PATH_NOT_FOUND:
 	case ERROR_INVALID_NAME:
 		return ENOENT;
+	case ERROR_INVALID_FUNCTION:
+		return EOPNOTSUPP;
 	default:
 		return win32_error;
 	}

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1250,8 +1250,9 @@ get_others_file_permissions(wchar_t * file_name, int isReadOnlyFile)
 		goto cleanup;
 	}
 
-	if (((is_valid_sid = IsValidSid(owner_sid)) == FALSE) || ((is_valid_acl = IsValidAcl(dacl)) == FALSE)) {
-		debug3("IsValidSid: %d; is_valid_acl: %d", is_valid_sid, is_valid_acl);
+	if (((is_valid_sid = IsValidSid(owner_sid)) == FALSE) || dacl == NULL ||
+		((is_valid_acl = IsValidAcl(dacl)) == FALSE)) {
+		debug3("IsValidSid: %d; NULL Acl: %d; IsValidAcl: %d", is_valid_sid, dacl == NULL, is_valid_acl);
 		goto cleanup;
 	}
 


### PR DESCRIPTION
- Updated Win32 error translation table to translate ERROR_INVALID_FUNCTION as EOPNOTSUPP which in turn allows the SFTP rename capability to failover to rename() when link()/unlink() combination does not work due to the volume not supporting it.
- Addressed file security descriptor with no defined DACL.
https://github.com/PowerShell/Win32-OpenSSH/issues/1357