### PR TITLE
Build failure on VS 2019

### DIFF
--- a/contrib/win32/win32compat/inc/fcntl.h
+++ b/contrib/win32/win32compat/inc/fcntl.h
@@ -16,8 +16,12 @@
 int w32_fcntl(int fd, int cmd, ... /* arg */);
 #define fcntl(a,b,...)		w32_fcntl((a), (b),  __VA_ARGS__)
 
+int w32_open(const char* pathname, int flags, ... /* arg */);
+#if _MSC_VER >= 1920  // VS 2019
+#define open w32_open
+#else
 #define open(a,b,...) w32_open((a), (b),  __VA_ARGS__)
-int w32_open(const char *pathname, int flags, ... /* arg */);
+#endif
 
 void* w32_fd_to_handle(int fd);
 

--- a/contrib/win32/win32compat/inc/unistd.h
+++ b/contrib/win32/win32compat/inc/unistd.h
@@ -29,9 +29,13 @@ int w32_write(int fd, const void *buf, size_t max);
 int w32_writev(int fd, const struct iovec *iov, int iovcnt);
 
 int w32_isatty(int fd);
+#if _MSC_VER >= 1920  // VS 2019
+#define isatty w32_isatty
+#else
 /* can't do this #define isatty w32_isatty
-* as there is a variable in code named isatty*/
+ * as there is a variable in code named isatty*/
 #define isatty(a)	w32_isatty((a))
+#endif
 
 int w32_close(int fd);
 #define close w32_close


### PR DESCRIPTION
I attempted to build `ssh.exe` on VS 2019, but it was failed due to incorrect `#define` for `isatty()` and `open()`.

I do not have VS 2017 or earlier, but I guess current implementation works fine on them. So I apply this fix to VS 2019 or later with `_MSC_VER`.