### PR TITLE
Fixed issue around incorrect handling of Handle and CredHandle types in Kerb GSS/SSPI adapter code

### DIFF
--- a/contrib/win32/openssh/version.rc
+++ b/contrib/win32/openssh/version.rc
@@ -69,7 +69,7 @@ BEGIN
         BEGIN
             VALUE "FileVersion", "8.0.0.0"
             VALUE "ProductName", "OpenSSH for Windows"
-            VALUE "ProductVersion", "OpenSSH_7.9p1 for Windows"
+            VALUE "ProductVersion", "OpenSSH_8.0p1 for Windows"
         END
     END
     BLOCK "VarFileInfo"

--- a/contrib/win32/win32compat/inc/gssapi.h
+++ b/contrib/win32/win32compat/inc/gssapi.h
@@ -47,7 +47,8 @@
 typedef uint32_t OM_uint32;
 
 typedef char *gss_name_struct, *gss_name_t;
-typedef CredHandle *gss_cred_id_t;
+
+typedef struct cred_st *gss_cred_id_t;
 typedef CtxtHandle *gss_ctx_id_t;
 
 typedef OM_uint32 gss_qop_t;

--- a/contrib/win32/win32compat/spawn-ext.c
+++ b/contrib/win32/win32compat/spawn-ext.c
@@ -13,8 +13,12 @@ __posix_spawn_asuser(pid_t *pidp, const char *path, const posix_spawn_file_actio
 
 	int r = -1;
 	/* use token generated from password auth if already present */
-	HANDLE user_token = password_auth_token;
-	if (sspi_auth_user) user_token = sspi_auth_user;
+	HANDLE user_token = NULL;
+	
+	if (password_auth_token)
+		user_token = password_auth_token;
+	else if (sspi_auth_user) 
+		user_token = sspi_auth_user;
 
 	if (!user_token && (user_token = get_user_token(user, 1)) == NULL) {
 		error("unable to get security token for user %s", user);


### PR DESCRIPTION
Prior logic was using a common variable to encapsulate both these types and doing a runtime check based on GetTokenInformation call to determine the actual underlying type. These two types are not guaranteed to have different values and any conflict could result in a random crash that would be nearly impossible to debug. 
