### PR TITLE
Pass prompted message to SSH_ASKPASS command line

### DIFF
--- a/readpass.c
+++ b/readpass.c
@@ -78,10 +78,11 @@ ssh_askpass(char *askpass, const char *msg)
 			signal(SIGCHLD, osigchld);
 			return NULL;
 		} else {
-			char* spawn_argv[2];
+			const char* spawn_argv[3];
 			spawn_argv[0] = askpass;
-			spawn_argv[1] = NULL;
-			if (posix_spawnp(&pid, spawn_argv[0], &actions, NULL, spawn_argv, NULL) != 0) {
+			spawn_argv[1] = msg;
+			spawn_argv[2] = NULL;
+			if (posix_spawnp(&pid, spawn_argv[0], &actions, NULL, (char* const*) spawn_argv, NULL) != 0) {
 				posix_spawn_file_actions_destroy(&actions);
 				error("ssh_askpass: posix_spawnp: %s", strerror(errno));
 				signal(SIGCHLD, osigchld);


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/1152
Issue:The msg parameter provided to the ssh_askpass function is not forwarded to the command specified by SSH_ASKPASS. This parameter specifies a prompt that should be forwarded as a command line argument to the SSH_ASKPASS-specified command. The logic is correct in the fork-based version but not the posix_spawn-based version of the code.

Fix:Change posix_spawn arguments to include prompt message
