### PR TITLE
Fixed passing of username between processes.

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -657,7 +657,7 @@ send_autxctx_state(Authctxt *auth, int fd)
 
 	if ((m = sshbuf_new()) == NULL)
 		fatal("%s: sshbuf_new failed", __func__);
-	if ((r = sshbuf_put_cstring(m, auth->pw->pw_name)) != 0)
+	if ((r = sshbuf_put_cstring(m, auth->user)) != 0)
 		fatal("%s: buffer error: %s", __func__, ssh_err(r));
 
 	if (ssh_msg_send(fd, 0, m) == -1)


### PR DESCRIPTION
In #327 there were some optimizations and the way how Authctxt is created in forked process, but the change introduced a bug - the user name sent between processes is `auth->pw->pw_name`, while the received one is stored to `auth->user`. This fix changes it to send `auth->user` as expected.