### PR TITLE
Fix build failure on VS 2019

### DIFF
--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -31,10 +31,10 @@
 * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <io.h>
 #include <fcntl.h>
 #include "inc/sys/stat.h"
 #include "inc/sys/types.h"
-#include <io.h>
 #include <errno.h>
 #include <stddef.h>
 #include <direct.h>

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -45,7 +45,6 @@
 #include <security.h>
 #include <ntstatus.h>
 
-#include "inc\unistd.h"
 #include "inc\sys\stat.h"
 #include "inc\sys\statvfs.h"
 #include "inc\sys\time.h"
@@ -54,6 +53,7 @@
 #include "inc\dirent.h"
 #include "inc\sys\types.h"
 #include "inc\sys\ioctl.h"
+#include "inc\unistd.h"
 #include "inc\fcntl.h"
 #include "inc\utf.h"
 #include "signal_internal.h"


### PR DESCRIPTION
The change of #390 might change the name of the variable isatty as stated in the comments.
That might not result in a compilation problem it could still be undisirable.

When the platfrom includes come after the define of e.g. isatty. This will break the platfrom header.
However, if the plafrom header is included before the define, there will be no change to the Original header.

This PR moved the includes, so the platfrom headers are first.