### PR TITLE
Potential Bug When First Character In Path Is Unicode

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1382,7 +1382,7 @@ is_absolute_path(const char *path)
 	if(*path == '\"' || *path == '\'') /* skip double quote if path is "c:\abc" */
 		path++;
 
-	if (*path == '/' || *path == '\\' || (*path != '\0' && isalpha(*path) && path[1] == ':') ||
+	if (*path == '/' || *path == '\\' || (*path != '\0' && __isascii(*path) && isalpha(*path) && path[1] == ':') ||
 	    ((strlen(path) >= strlen(PROGRAM_DATA)) && (memcmp(path, PROGRAM_DATA, strlen(PROGRAM_DATA)) == 0)))
 		retVal = 1;
 


### PR DESCRIPTION
- Use of isalpha() is undefined for non-ASCII values and will throw an assertion when in debug mode.  This is only a problem when the first character in the path is a unicode character.  This change ensures the character is within the appropriate range before evaluation with isalpha().