### PR TITLE
Support for AuthorizedKeysCommand and AuthorizedPrincipal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,3 +301,6 @@ __pycache__/
 contrib/win32/win32compat/inc/crtheaders.h
 
 contrib/win32/openssh/LibreSSLSDK/
+
+OpenSSH-Win64_symbols/
+UnitTests/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,19 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE",
+                "WINDOWS",
+                "FORK_NOT_SUPPORTED"
+            ],
+            "intelliSenseMode": "msvc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/auth.c
+++ b/auth.c
@@ -434,13 +434,6 @@ expand_authorized_keys(const char *filename, struct passwd *pw)
 	file = percent_expand(filename, "h", pw->pw_dir,
 	    "u", pw->pw_name, "U", uidstr, (char *)NULL);
 
-#ifdef WINDOWS
-	/* Return if the path is absolute. If not, prepend the '%h\\' */
-	if(is_absolute_path(file))
-		return (file);
-
-	i = snprintf(ret, sizeof(ret), "%s\\%s", pw->pw_dir, file);
-#else
 	/*
 	 * Ensure that filename starts anchored. If not, be backward
 	 * compatible and prepend the '%h/'
@@ -449,7 +442,6 @@ expand_authorized_keys(const char *filename, struct passwd *pw)
 		return (file);
 
 	i = snprintf(ret, sizeof(ret), "%s/%s", pw->pw_dir, file);
-#endif // WINDOWS
 
 	if (i < 0 || (size_t)i >= sizeof(ret))
 		fatal("expand_authorized_keys: path too long");

--- a/contrib/win32/openssh/OpenSSHBuildHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHBuildHelper.psm1
@@ -357,7 +357,7 @@ function Start-OpenSSHPackage
     $payload += "FixHostFilePermissions.ps1", "FixUserFilePermissions.ps1", "OpenSSHUtils.psm1", "OpenSSHUtils.psd1"
     $payload += "openssh-events.man"
 
-    $packageName = "OpenSSH-Win64"
+    $packageName = "OpenSSH-Win64$(if ('Debug' -eq $Configuration) { "-$Configuration" })"
     if ($NativeHostArch -ieq 'x86') {
         $packageName = "OpenSSH-Win32"
     }
@@ -428,7 +428,7 @@ function Start-OpenSSHPackage
         Remove-Item ($packageDir + '.zip') -Force -ErrorAction SilentlyContinue
         if(get-command Compress-Archive -ErrorAction SilentlyContinue)
         {
-            Compress-Archive -Path $packageDir -DestinationPath ($packageDir + '.zip')
+            Compress-Archive -Path $packageDir\* -DestinationPath ($packageDir + '.zip')
             Write-BuildMsg -AsInfo -Message "Packaged Payload - '$packageDir.zip'"
         }
         else
@@ -446,7 +446,7 @@ function Start-OpenSSHPackage
         Remove-Item ($symbolsDir + '.zip') -Force -ErrorAction SilentlyContinue
         if(get-command Compress-Archive -ErrorAction SilentlyContinue)
         {
-            Compress-Archive -Path $symbolsDir -DestinationPath ($symbolsDir + '.zip')
+            Compress-Archive -Path $symbolsDir\* -DestinationPath ($symbolsDir + '.zip')
             Write-BuildMsg -AsInfo -Message "Packaged Symbols - '$symbolsDir.zip'"
         }
         else

--- a/contrib/win32/win32compat/Debug.h
+++ b/contrib/win32/win32compat/Debug.h
@@ -8,7 +8,7 @@ void     debug2(const char *, ...);
 void     debug3(const char *, ...);
 
 /* Enable the following for verbose logging */
-#if (0)
+#if _DEBUG
 #define debug4 debug2
 #define debug5 debug3
 #else

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -66,6 +66,8 @@
 
 #include <wchar.h>
 
+extern int xasprintf(char **, const char *, ...);
+
 static char* s_programdir = NULL;
 
 /* Maximum reparse buffer info size. The max user defined reparse

--- a/readconf.c
+++ b/readconf.c
@@ -480,13 +480,12 @@ default_ssh_port(void)
 static int
 execute_in_shell(const char *cmd)
 {
+#ifdef WINDOWS
+	return system(cmd);
+#else
 	char *shell;
 	pid_t pid;
 	int devnull, status;
-
-#ifdef WINDOWS
-	return system(cmd);
-#endif
 
 	if ((shell = getenv("SHELL")) == NULL)
 		shell = _PATH_BSHELL;
@@ -538,6 +537,7 @@ execute_in_shell(const char *cmd)
 	}
 	debug3("command returned status %d", WEXITSTATUS(status));
 	return WEXITSTATUS(status);
+#endif
 }
 
 /*

--- a/servconf.c
+++ b/servconf.c
@@ -2038,10 +2038,11 @@ process_server_config_line(ServerOptions *options, char *line,
 			    linenum);
 		len = strspn(cp, WHITESPACE);
 		if (*activep && options->authorized_keys_command == NULL) {
-			if (cp[len] != '/' && strcasecmp(cp + len, "none") != 0)
+			if (strcasecmp(cp + len, "none") != 0 && !path_absolute(cp + len))
 				fatal("%.200s line %d: AuthorizedKeysCommand "
 				    "must be an absolute path",
 				    filename, linenum);
+
 			options->authorized_keys_command = xstrdup(cp + len);
 		}
 		return 0;
@@ -2064,12 +2065,12 @@ process_server_config_line(ServerOptions *options, char *line,
 		len = strspn(cp, WHITESPACE);
 		if (*activep &&
 		    options->authorized_principals_command == NULL) {
-			if (cp[len] != '/' && strcasecmp(cp + len, "none") != 0)
+			if (strcasecmp(cp + len, "none") != 0 && !path_absolute(cp + len))
 				fatal("%.200s line %d: "
 				    "AuthorizedPrincipalsCommand must be "
 				    "an absolute path", filename, linenum);
-			options->authorized_principals_command =
-			    xstrdup(cp + len);
+
+			options->authorized_principals_command = xstrdup(cp + len);
 		}
 		return 0;
 

--- a/sshfileperm.h
+++ b/sshfileperm.h
@@ -26,4 +26,8 @@
 #define _SSH_FILE_PERM_H
 
 int check_secure_file_permission(const char *, struct passwd *);
+#ifdef WINDOWS
+char* get_execpath(const char **av);
+#endif
+
 #endif /* _SSH_FILE_PERM_H */


### PR DESCRIPTION
# Support for AuthorizedKeysCommand and AuthorizedPrincipal

This PR implements the support for spawning child processes from the SSH Daemon
(Service), so that the configuration items `AuthorizedKeysCommand` and
`AuthorizedPrincipalCommand` can be utilized under Windows as well.

The implementation not only supports standard Windows executables but is capable
of spawning PowerShell Skripts. Under all Unix derivates a special handling of
shell scripts isnt't necessary because those platforms support the start of
script as (normal) executables via the Shebang notation. This technique isn't
available under Windows, so the pull request supports using Powershell scripts
with a special handling (treatment). 

The following excerpt from the sshd.log file depicts this implementation

```
6628 2019-10-11 17:01:37.935 debug3: subprocess: AuthorizedKeysCommand command "C:\\\\windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe -nop -nol -noni -file c:\\\\ProgramData\\\\ssh\\\\Find-RSAKey.ps1 devtest\\\\ee022bf" running as sshd (flags 0x6)
6628 2019-10-11 17:01:37.935 debug3: get_execpath: Powershell Core Path [C:\\Program Files\\PowerShell]
6628 2019-10-11 17:01:37.935 debug3: get_execpath: Powershell Path [C:\\windows\\System32\\WindowsPowerShell]
6628 2019-10-11 17:01:37.935 debug3: get_execpath: Checking path for Powershell reference: C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe
6628 2019-10-11 17:01:37.935 debug3: get_execpath: Found Powershell trying to find -f parameter
6628 2019-10-11 17:01:37.935 debug3: get_execpath: Found -File Powershell parameter: c:\\ProgramData\\ssh\\Find-RSAKey.ps1
6628 2019-10-11 17:01:37.935 debug3: subprocess: Checking exec path [c:\\ProgramData\\ssh\\Find-RSAKey.ps1] for secure file permissions
6628 2019-10-11 17:01:37.935 debug2: pipe - r-h:632,io:000001E7C150A710,fd:5  w-h:628,io:000001E7C1509710,fd:8
6628 2019-10-11 17:01:37.935 debug3: subprocess: Spawning process: C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe
6628 2019-10-11 17:01:37.935 debug3: spawning "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -nop -nol -noni -file c:\\ProgramData\\ssh\\Find-RSAKey.ps1 devtest\\ee022bf
```

With the support of `AuthorizedKeysCommand` and PowerShell scripts, it is
possible to store the approved SSH Public-Keys for a user in an Azure KeyVault
or Storage Account and to transfer the keys to the SSH service via the Az
Powershell Modules, which itself uitilize an authentication via the Managed
Indentity of the virtual machine to access the information in the KeyVault or
Storage Account.


I explicitly mention @nomorefood and @manojampalam to request a review on this PR.