### PR TITLE
Fix comparison between wchar and ptr

### DIFF
--- a/contrib/win32/win32compat/shell-host.c
+++ b/contrib/win32/win32compat/shell-host.c
@@ -1486,7 +1486,7 @@ wmain(int ac, wchar_t **av)
 	while (*exec_command != L'\0' && *exec_command == L' ')
 		exec_command++;
 
-	if (exec_command == L'\0')
+	if (*exec_command == L'\0')
 		goto usage;
 
 	if (with_pty)


### PR DESCRIPTION
Minor: shell-host attempts to check for a empty command line after removing white space but instead of comparing the character at the start of the string with NUL it directly compares NUL to the pointer itself.