### PR TITLE
fix onecore build issues

### DIFF
--- a/contrib/win32/openssh/OpenSSHBuildHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHBuildHelper.psm1
@@ -592,7 +592,7 @@ function Start-OpenSSHBuild
         $win10SDKVer = Get-Windows10SDKVersion
         [XML]$xml = Get-Content $PathTargets
         $xml.Project.PropertyGroup.WindowsSDKVersion = $win10SDKVer.ToString()
-        $xml.Project.PropertyGroup.AdditionalDependentLibs = 'onecore.lib'
+        $xml.Project.PropertyGroup.AdditionalDependentLibs = 'onecore.lib;shlwapi.lib'
         $xml.Project.PropertyGroup.MinimalCoreWin = 'true'
         
         #Use onecore libcrypto binaries


### PR DESCRIPTION
34>posix_compat.lib(misc.obj) : error LNK2001: unresolved external symbol __imp_PathMatchSpecW [C:\OpenSSH\contrib\win32\openssh\sshd.vcxproj]
 34>C:\OpenSSH\contrib\win32\openssh\..\..\..\bin\x64\Release\sshd.exe : fatal error LNK1120: 1 unresolved externals [C:\OpenSSH\contrib\win32\openssh\sshd.vcxproj]
 34>C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Microsoft.CppCommon.targets(638,5): error MSB6006: "link.exe" exited with code 1120. [C:\OpenSSH\contrib\win32\openssh\sshd.vcxproj]
 34>Done Building Project "C:\OpenSSH\contrib\win32\openssh\sshd.vcxproj" (Rebuild target(s)) -- FAILED.
 9>Done Building Project "C:\OpenSSH\contrib\win32\openssh\sshd.vcxproj.metaproj" (Rebuild target(s)) -- FAILED.
 1>Done Building Project "C:\OpenSSH\contrib\win32\openssh\Win32-OpenSSH.sln" (Rebuild target(s)) -- FAILED.