### PR TITLE
Fix user SID resolution when user name is same as computer name.

### DIFF
--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -237,7 +237,7 @@ get_passwd(const wchar_t * user_utf16, PSID sid)
 	}
 
 	/* If standard local user name, just use name without decoration */
-	if ((_wcsicmp(domain_name, computer_name) == 0))
+	if ((_wcsicmp(domain_name, computer_name) == 0) && (_wcsicmp(computer_name, user_name) != 0))
 		wcscpy_s(user_resolved, ARRAYSIZE(user_resolved), user_name);
 
 	/* put any other format in sam compatible format */


### PR DESCRIPTION
The following happens for case when computer name is same as user name:

1. main calls getpwuid/w32_getpwuid/get_passwd to get current user name
2. during reading of file, check_secure_file_permission calls get_sid with
   user name, but gets SID of computer
3. check_secure_file_permission gets SID of config file owner
4. check_secure_file_permission checks if config SID matches user SID, but
   this fails, because it actually checks it against computer SID

Solution is to use fully qualified name instead and return it from
get_passwd.