### PR TITLE
Reset console after exiting raw mode

### DIFF
--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -227,8 +227,12 @@ ConEnterRawMode()
 void 
 ConExitRawMode()
 {
-	SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), stdin_dwSavedAttributes);
-	SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), stdout_dwSavedAttributes);
+	if (0 == in_raw_mode) {
+		return;
+	}
+
+	SetConsoleMode(GetConsoleInputHandle(), stdin_dwSavedAttributes);
+	SetConsoleMode(GetConsoleOutputHandle(), stdout_dwSavedAttributes);
 
 	if (FALSE == isAnsiParsingRequired) {
 		if (console_out_cp_saved) {


### PR DESCRIPTION
The wrong handle was being reset when exiting raw mode. The console
CONIN$ was being modified, and STD_INPUT_HANDLE was the handle that was
being reset. These may not be the same handle. In some cases, this meant
that the console was being left in ENABLE_VIRTUAL_TERMINAL_INPUT mode,
which could break some programs from being run in the same terminal
window after using SSH, since it would look like stdin wasn't working
and they would look like they were frozen.