### PR TITLE
Relax implicit ASKPASS requirements on Windows in X11 forwarding scenarios

### DIFF
--- a/readpass.c
+++ b/readpass.c
@@ -183,10 +183,19 @@ read_passphrase(const char *prompt, int flags)
 			askpass = getenv(SSH_ASKPASS_ENV);
 		else
 			askpass = _PATH_SSH_ASKPASS_DEFAULT;
+
+#ifdef WINDOWS
+		if (getenv(SSH_ASKPASS_ENV)) {
+#endif
+
 		if ((ret = ssh_askpass(askpass, prompt)) == NULL)
 			if (!(flags & RP_ALLOW_EOF))
 				return xstrdup("");
 		return ret;
+
+#ifdef WINDOWS
+		}
+#endif
 	}
 
 	if (readpassphrase(prompt, buf, sizeof buf, rppflags) == NULL) {


### PR DESCRIPTION
For historical reasons, if environment variable `DISPLAY` exists, `read_passphrase` will force users down a path that **requires** use of an askpass implementation specified via `SSH_ASKPASS` (or internal defaults). On Windows, where askpass generally won't exist, this will result in complete login failure.

[There is on-going discussion](https://bugzilla.mindrot.org/show_bug.cgi?id=69)--18 years and going--about refactoring `read_passphrase` to eliminate this behavior and introduce controls to give users explicit control over `SSH_ASKPASS` behavior.

The following constraints were assumed:
* Don't change non-Windows behavior at all
* Keep compatibility with `SSH_ASKPASS` users on Windows
* Minimize diff to maintain attractiveness for upstream consideration

(fixes PowerShell/Win32-OpenSSH#1515)