### PR TITLE
Reset the console code page before exiting

### DIFF
--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -198,17 +198,22 @@ ConEnterRawMode()
 		debug("console doesn't support the ansi parsing");
 	} else {
 		debug("ENABLE_VIRTUAL_TERMINAL_PROCESSING is supported. Console supports the ansi parsing");
-		console_out_cp_saved = GetConsoleOutputCP();
-		console_in_cp_saved = GetConsoleCP();
-		if (SetConsoleOutputCP(CP_UTF8))
-			debug3("Successfully set console output code page from:%d to %d", console_out_cp_saved, CP_UTF8);
-		else
-			error("Failed to set console output code page from:%d to %d error:%d", console_out_cp_saved, CP_UTF8, GetLastError());
 
-		if (SetConsoleCP(CP_UTF8))
-			debug3("Successfully set console input code page from:%d to %d", console_in_cp_saved, CP_UTF8);
-		else
-			error("Failed to set console input code page from:%d to %d error:%d", console_in_cp_saved, CP_UTF8, GetLastError());
+		console_out_cp_saved = GetConsoleOutputCP();
+		if (console_out_cp_saved) {
+			if (SetConsoleOutputCP(CP_UTF8))
+				debug3("Successfully set console output code page from:%d to %d", console_out_cp_saved, CP_UTF8);
+			else
+				error("Failed to set console output code page from:%d to %d error:%d", console_out_cp_saved, CP_UTF8, GetLastError());
+		}
+
+		console_in_cp_saved = GetConsoleCP();
+		if (console_in_cp_saved) {
+			if (SetConsoleCP(CP_UTF8))
+				debug3("Successfully set console input code page from:%d to %d", console_in_cp_saved, CP_UTF8);
+			else
+				error("Failed to set console input code page from:%d to %d error:%d", console_in_cp_saved, CP_UTF8, GetLastError());
+		}
 
 		if (track_view_port) {
 			ConSaveViewRect();

--- a/contrib/win32/win32compat/win32-utf8.c
+++ b/contrib/win32/win32compat/win32-utf8.c
@@ -65,7 +65,6 @@ snmprintf(char *buf, size_t len, int *written, const char *fmt, ...)
 void
 msetlocale(void)
 {
-	// allow console output of unicode characters
-	SetConsoleOutputCP(CP_UTF8);
+	// Do nothing
+	// The code page is changed to UTF-8 in ConEnterRawMode()
 }
-


### PR DESCRIPTION
The console's input and output code pages may not have been properly
reset when the process exits.

First, the output page was being forced to UTF8 without the previous
value being saved. This can be removed since we are already setting the
codepage ourselves in a later function call.

Second, GetConsoleCP() and GetConsoleOutputCP() can fail and return 0,
leaving us without a saved version of the previous value if we then
immediately set the code page without checking the result of the above
functions. Also note that, because they are called after we have already
forced UTF8, we are incorrectly restoring to UTF8 even when the call to
GetConsoleOutputCP() succeeds.