### PR TITLE
Updates the Win32 error translation table to translate ERROR_NOT_SUPPORTED to EOPNOTSUPP

### DIFF
--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -99,6 +99,7 @@ errno_from_Win32Error(int win32_error)
 	case ERROR_INVALID_NAME:
 		return ENOENT;
 	case ERROR_INVALID_FUNCTION:
+	case ERROR_NOT_SUPPORTED:
 		return EOPNOTSUPP;
 	default:
 		return win32_error;


### PR DESCRIPTION
This fixes detection of filesystems that do not support hardlinks and return ERROR_NOT_SUPPORTED rather than ERROR_INVALID_FUNCTION when a hardlink is attempted.

In turn this enables the SFTP rename capability to failover correctly to rename() when the link()/unlink() combination does not work instead of returning an error to the client.

An example of a filesystem which uses ERROR_NOT_SUPPORTED when hardlinks are not supported instead of ERROR_INVALID_FUNCTION is DrivePool (https://stablebit.com).