### PR TITLE
Fallback onto TEMP if TMPDIR undefined

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -1506,7 +1506,15 @@ mktemp_proto(char *s, size_t len)
 	const char *tmpdir;
 	int r;
 
-	if ((tmpdir = getenv("TMPDIR")) != NULL) {
+	tmpdir = getenv("TMPDIR");
+
+#ifdef WINDOWS
+	if (tmpdir == NULL) {
+		tmpdir = getenv("TEMP");
+	}
+#endif
+
+	if (tmpdir != NULL) {
 		r = snprintf(s, len, "%s/ssh-XXXXXXXXXXXX", tmpdir);
 		if (r > 0 && (size_t)r < len)
 			return;


### PR DESCRIPTION
`mktemp_proto` is called to generate an untrusted X11 auth cookie. This function builds a temporary cookie path by reading environment variable `TMPDIR` or, if that fails, simply assuming `/tmp` exists. On Windows, neither the environment variable or `/tmp` path exist. This results in X11 untrusted scenario failure.

This PR changes `mktemp_proto` to read environment variable `TEMP` before resorting to the hardcoded `/tmp`. This variable ships with Windows and points to the user's local AppData temp folder by default.

The following constraints were assumed:
- Don't change non-Windows behavior at all (guards in place to prevent this)
- Minimize diff to maintain attractiveness for upstream consideration

(fixes PowerShell/Win32-OpenSSH#1563, PowerShell/Win32-OpenSSH#1593)