### PR TITLE
Quote XAuthLocation before use

### DIFF
--- a/clientloop.c
+++ b/clientloop.c
@@ -357,11 +357,20 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 					/* Don't overflow on long timeouts */
 					x11_timeout_real = UINT_MAX;
 				}
+#ifdef WINDOWS
+				xasprintf(&cmd, "\"%s\" -f %s generate %s %s "
+					"untrusted timeout %u 2>%s",
+					xauth_path, xauthfile, display,
+					SSH_X11_PROTO, x11_timeout_real,
+					_PATH_DEVNULL);
+#else
 				xasprintf(&cmd, "%s -f %s generate %s %s "
-				    "untrusted timeout %u 2>%s",
-				    xauth_path, xauthfile, display,
-				    SSH_X11_PROTO, x11_timeout_real,
-				    _PATH_DEVNULL);
+					"untrusted timeout %u 2>%s",
+					xauth_path, xauthfile, display,
+					SSH_X11_PROTO, x11_timeout_real,
+					_PATH_DEVNULL);
+#endif
+
 			}
 			debug2("%s: xauth command: %s", __func__, cmd);
 
@@ -385,12 +394,21 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 		 * above.
 		 */
 		if (trusted || generated) {
+#ifdef WINDOWS
 			xasprintf(&cmd,
-			    "%s %s%s list %s 2>" _PATH_DEVNULL,
+			    "\"%s\" %s%s list %s 2>" _PATH_DEVNULL,
 			    xauth_path,
 			    generated ? "-f " : "" ,
 			    generated ? xauthfile : "",
 			    display);
+#else
+			xasprintf(&cmd,
+				"%s %s%s list %s 2>" _PATH_DEVNULL,
+				xauth_path,
+				generated ? "-f " : "",
+				generated ? xauthfile : "",
+				display);
+#endif
 			debug2("x11_get_proto: %s", cmd);
 			f = popen(cmd, "r");
 			if (f && fgets(line, sizeof(line), f) &&

--- a/clientloop.c
+++ b/clientloop.c
@@ -362,10 +362,10 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 #else
 				xasprintf(&cmd, "%s -f %s generate %s %s "
 #endif
-					"untrusted timeout %u 2>%s",
-					xauth_path, xauthfile, display,
-					SSH_X11_PROTO, x11_timeout_real,
-					_PATH_DEVNULL);
+				    "untrusted timeout %u 2>%s",
+				    xauth_path, xauthfile, display,
+				    SSH_X11_PROTO, x11_timeout_real,
+				    _PATH_DEVNULL);
 			}
 			debug2("%s: xauth command: %s", __func__, cmd);
 
@@ -395,10 +395,10 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 #else
 				"%s %s%s list %s 2>" _PATH_DEVNULL,
 #endif
-				xauth_path,
-				generated ? "-f " : "",
-				generated ? xauthfile : "",
-				display);
+			    xauth_path,
+			    generated ? "-f " : "" ,
+			    generated ? xauthfile : "",
+			    display);
 			debug2("x11_get_proto: %s", cmd);
 			f = popen(cmd, "r");
 			if (f && fgets(line, sizeof(line), f) &&

--- a/clientloop.c
+++ b/clientloop.c
@@ -359,18 +359,13 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 				}
 #ifdef WINDOWS
 				xasprintf(&cmd, "\"%s\" -f %s generate %s %s "
-					"untrusted timeout %u 2>%s",
-					xauth_path, xauthfile, display,
-					SSH_X11_PROTO, x11_timeout_real,
-					_PATH_DEVNULL);
 #else
 				xasprintf(&cmd, "%s -f %s generate %s %s "
+#endif
 					"untrusted timeout %u 2>%s",
 					xauth_path, xauthfile, display,
 					SSH_X11_PROTO, x11_timeout_real,
 					_PATH_DEVNULL);
-#endif
-
 			}
 			debug2("%s: xauth command: %s", __func__, cmd);
 
@@ -394,21 +389,16 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 		 * above.
 		 */
 		if (trusted || generated) {
+			xasprintf(&cmd,
 #ifdef WINDOWS
-			xasprintf(&cmd,
-			    "\"%s\" %s%s list %s 2>" _PATH_DEVNULL,
-			    xauth_path,
-			    generated ? "-f " : "" ,
-			    generated ? xauthfile : "",
-			    display);
+				"\"%s\" %s%s list %s 2>" _PATH_DEVNULL,
 #else
-			xasprintf(&cmd,
 				"%s %s%s list %s 2>" _PATH_DEVNULL,
+#endif
 				xauth_path,
 				generated ? "-f " : "",
 				generated ? xauthfile : "",
 				display);
-#endif
 			debug2("x11_get_proto: %s", cmd);
 			f = popen(cmd, "r");
 			if (f && fgets(line, sizeof(line), f) &&


### PR DESCRIPTION
`XAuthLocation` is supported in ssh configuration data and specifies the full pathname to an xauth binary (e.g. `"C:\Program Files\VcXsrv\xauth.exe"`). On Windows, this is passed to the command interpreter (via _wsystem), which requires paths with spaces to be escaped or quoted. Use of a path with spaces will fail some X11 scenarios.

This PR simply adds double-quotes `" "` around `XAuthLocation` paths right before they're used in X11 scenarios on Windows.

The following constraints were assumed:
- Zero impact to non-Windows platforms (ifdef guards in place)
- Minimize diff to maintain attractiveness for upstream consideration

(fixes PowerShell/Win32-OpenSSH#1563, PowerShell/Win32-OpenSSH#1593)