### PR TITLE
user permission fix to include ecdsa and ed25519

### DIFF
--- a/contrib/win32/openssh/FixUserFilePermissions.ps1
+++ b/contrib/win32/openssh/FixUserFilePermissions.ps1
@@ -10,7 +10,7 @@ if(Test-Path ~\.ssh\config -PathType Leaf)
     Repair-UserSshConfigPermission -FilePath ~\.ssh\config @psBoundParameters
 }
 
-Get-ChildItem ~\.ssh\* -Include "id_rsa","id_dsa" -ErrorAction SilentlyContinue | % {
+Get-ChildItem ~\.ssh\* -Include "id_rsa","id_dsa","id_ecdsa","id_ed25519" -ErrorAction SilentlyContinue | ForEach-Object {
     Repair-UserKeyPermission -FilePath $_.FullName @psBoundParameters
 }
 


### PR DESCRIPTION
the FixUserFilePermissions.ps1 script that ensures adequate permissions are set on a user's private keys omits two well known key types.  This short easy change will ensure that privates keys for these two newer algorightms (ecdsa and ed25519) are also checked and adjusted accordingly.

There is also a minor alias expansion -- I figured I would do that while I was on that line.