### PR TITLE
Update _PATH_TTY to point to the console

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -456,8 +456,12 @@ struct winsize {
 #define _PATH_UNIX_X X_UNIX_PATH
 
 #ifndef _PATH_TTY
-# define _PATH_TTY "/dev/tty"
-#endif
+#  ifdef _WIN32
+#    define _PATH_TTY "conin$"
+#  else
+#    define _PATH_TTY "/dev/tty"
+#  endif /* _WIN32 */
+#endif /* _PATH_TTY */
 
 /* Macros */
 


### PR DESCRIPTION
Currently openssh tests for a TTY by opening /dev/tty which does not exist on Windows. It most cases this then falls back to a prompt that works, but if the DISPLAY env var is set, then it tries to spawn "/usr/X11R6/bin/ssh-askpass" and fails.
Fixes PowerShell/Win32-OpenSSH#966,
fixes PowerShell/Win32-OpenSSH#1515,
fixes PowerShell/Win32-OpenSSH#762,
fixes PowerShell/Win32-OpenSSH#1088,
fixes PowerShell/Win32-OpenSSH#1356,
and probably others.

Possible workarounds are to create a file `C:\dev\tty` so that it is able to open it, or to unset the DISPLAY variable, but it would be better if OpenSSH could detect this is a valid console. Code is from https://github.com/PowerShell/Win32-OpenSSH/issues/966#issuecomment-461989704