### PR TITLE
Fix delay in case of ssh's ConnectTimeout option usage

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -241,7 +241,7 @@ set_rdomain(int fd, const char *name)
  * Returns 0 if fd ready or -1 on timeout or error (see errno).
  *
  */
-static int
+int
 waitfd(int fd, int *timeoutp, short events)
 {
 	struct pollfd pfd;

--- a/misc.c
+++ b/misc.c
@@ -241,7 +241,7 @@ set_rdomain(int fd, const char *name)
  * Returns 0 if fd ready or -1 on timeout or error (see errno).
  *
  */
-int
+static int
 waitfd(int fd, int *timeoutp, short events)
 {
 	struct pollfd pfd;
@@ -274,7 +274,7 @@ waitfd(int fd, int *timeoutp, short events)
  * Returns 0 if fd ready or -1 on timeout or error (see errno).
  *
  */
-static int
+int
 waitrfd(int fd, int *timeoutp)
 {
     return waitfd(fd, timeoutp, POLLIN);


### PR DESCRIPTION
I have timeout degradation in case of powershell version usage 
For example, ConnectionTimeout=5 produces 5 sec delay in any case.
ssh -o BatchMode=yes -o ServerAliveInterval=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 user@target uname
In real connection takes about 200ms
As I can see, https://github.com/openssh/openssh-portable includes fix for that, Let's apply patch here.
Thanks, Kirill