### PR TITLE
Add support for AuthorizedKeysCommand and AuthorizedPrincipalsCommand to run as System

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -956,9 +956,7 @@ subprocess(const char *tag, struct passwd *pw, const char *command,
 			posix_spawn_file_actions_adddup2(&actions, p[1], STDOUT_FILENO) != 0)
 			fatal("posix_spawn initialization failed");  
 		else {
-			//debug("GCE pw_name=%s", pw->pw_name);
-			//TODO (bxk): Remove hardcoded "system". Update logic so that when authorizedkeyscommanduser is not specified in the config, posix_spawnp is used instead of __posix_spawn_asuser
-			if (strcmp(pw->pw_name, "system") == 0) {
+			if (strcmp(pw->pw_name, "system") == 0 && am_system()) {
 				debug("starting subprocess using posix_spawnp");
 				if (posix_spawnp((pid_t*)&pid, av[0], &actions, NULL, av, NULL) != 0)
 					fatal("posix_spawnp: %s", strerror(errno));

--- a/auth.c
+++ b/auth.c
@@ -954,7 +954,7 @@ subprocess(const char *tag, struct passwd *pw, const char *command,
 
 		if (posix_spawn_file_actions_init(&actions) != 0 ||
 			posix_spawn_file_actions_adddup2(&actions, p[1], STDOUT_FILENO) != 0)
-			fatal("posix_spawn initialization failed");  
+			fatal("posix_spawn initialization failed");
 		else {
 			if (strcmp(pw->pw_name, "system") == 0 && am_system()) {
 				debug("starting subprocess using posix_spawnp");

--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -236,8 +236,11 @@ get_passwd(const wchar_t * user_utf16, PSID sid)
 		goto cleanup;
 	}
 
-	/* If standard local user name, just use name without decoration */
-	if ((_wcsicmp(domain_name, computer_name) == 0) && (_wcsicmp(computer_name, user_name) != 0))
+	/* if standard local user name or system account, just use name without decoration */
+	const SID_IDENTIFIER_AUTHORITY nt_authority = SECURITY_NT_AUTHORITY;
+	if ((_wcsicmp(domain_name, computer_name) == 0) && (_wcsicmp(computer_name, user_name) != 0) ||
+		memcmp(&nt_authority, GetSidIdentifierAuthority((PSID)binary_sid), sizeof(SID_IDENTIFIER_AUTHORITY)) == 0 && (
+		((SID*)binary_sid)->SubAuthority[0] == SECURITY_LOCAL_SYSTEM_RID))
 		wcscpy_s(user_resolved, ARRAYSIZE(user_resolved), user_name);
 
 	/* put any other format in sam compatible format */

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1074,7 +1074,6 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 	
 	wchar_t * t = cmdline_utf16;
 	do {
-		//debug3("spawning %ls", t);
 		if (as_user) {
 			debug3("spawning %ls as user", t);
 			b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1074,11 +1074,15 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 	
 	wchar_t * t = cmdline_utf16;
 	do {
-		debug3("spawning %ls", t);
-		if (as_user)
+		//debug3("spawning %ls", t);
+		if (as_user) {
+			debug3("spawning %ls as user", t);
 			b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
-		else
+		}
+		else {
+			debug3("spawning %ls as subprocess", t);
 			b = CreateProcessW(NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
+		}
 		if(b || GetLastError() != ERROR_FILE_NOT_FOUND || (argv != NULL && *argv != NULL) || cmd[0] == '\"')
 			break;
 		t++;


### PR DESCRIPTION
Add support for AuthorizedKeysCommand and AuthorizedPrincipalsCommand to run as System
- Adds support for system account lookup. This contribution is from @NoMoreFood's [unsubmitted branch](https://github.com/NoMoreFood/openssh-portable/commit/64d4c840dc6ae986c6f5c1a150c0348843367bea).
- When sshd is run as system and provided username is system, run command as subprocess using posix_spawnp
- Improve debug logging in spawn_child_internal by providing different logging message for when CreateProcessW and CreateProcessAsUserW are called.

Fixes #1546