### PR TITLE
Add support for AuthorizedKeysCommand and AuthorizedPrincipalsCommand to run as System

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -955,8 +955,18 @@ subprocess(const char *tag, struct passwd *pw, const char *command,
 		if (posix_spawn_file_actions_init(&actions) != 0 ||
 			posix_spawn_file_actions_adddup2(&actions, p[1], STDOUT_FILENO) != 0)
 			fatal("posix_spawn initialization failed");
-		else if (__posix_spawn_asuser((pid_t*)&pid, av[0], &actions, NULL, av, NULL, pw->pw_name) != 0)
-			fatal("posix_spawn: %s", strerror(errno));
+		else {
+			if (strcmp(pw->pw_name, "system") == 0 && am_system()) {
+				debug("starting subprocess using posix_spawnp");
+				if (posix_spawnp((pid_t*)&pid, av[0], &actions, NULL, av, NULL) != 0)
+					fatal("posix_spawnp: %s", strerror(errno));
+			}
+			else {
+				debug("starting subprocess as user using __posix_spawn_asuser");
+				if (__posix_spawn_asuser((pid_t*)&pid, av[0], &actions, NULL, av, NULL, pw->pw_name) != 0)
+					fatal("posix_spawn_user: %s", strerror(errno));
+			}
+		}
 
 		posix_spawn_file_actions_destroy(&actions);
 	}

--- a/auth.c
+++ b/auth.c
@@ -899,7 +899,6 @@ subprocess(const char *tag, struct passwd *pw, const char *command,
 	char *cp, errmsg[512];
 	u_int envsize;
 	char **child_env;
-	BOOL child_process = FALSE;
 
 	if (child != NULL)
 		*child = NULL;
@@ -939,10 +938,6 @@ subprocess(const char *tag, struct passwd *pw, const char *command,
 		restore_uid();
 		return 0;
 	}
-	/* If the user's SID is the System SID and sshd is running as
-	 * system, set to launch as a child process
-	 */
-	child_process = IsWellKnownSid(get_sid(pw->pw_name), WinLocalSystemSid) && am_system();
 #else
 	if (safe_path(av[0], &st, NULL, 0, errmsg, sizeof(errmsg)) != 0) {
 		error("Unsafe %s \"%s\": %s", tag, av[0], errmsg);
@@ -968,7 +963,10 @@ subprocess(const char *tag, struct passwd *pw, const char *command,
 			posix_spawn_file_actions_adddup2(&actions, p[1], STDOUT_FILENO) != 0)
 			fatal("posix_spawn initialization failed");
 		else {
-			if (child_process) {
+			/* If the user's SID is the System SID and sshd is running as system,
+			 * launch as a child process.
+			 */
+			if (IsWellKnownSid(get_sid(pw->pw_name), WinLocalSystemSid) && am_system()) {
 				debug("starting subprocess using posix_spawnp");
 				if (posix_spawnp((pid_t*)&pid, av[0], &actions, NULL, av, NULL) != 0)
 					fatal("posix_spawnp: %s", strerror(errno));

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1074,11 +1074,14 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 	
 	wchar_t * t = cmdline_utf16;
 	do {
-		debug3("spawning %ls", t);
-		if (as_user)
+		if (as_user) {
+			debug3("spawning %ls as user", t);
 			b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
-		else
+		}
+		else {
+			debug3("spawning %ls as subprocess", t);
 			b = CreateProcessW(NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
+		}
 		if(b || GetLastError() != ERROR_FILE_NOT_FOUND || (argv != NULL && *argv != NULL) || cmd[0] == '\"')
 			break;
 		t++;


### PR DESCRIPTION
Add support for AuthorizedKeysCommand and AuthorizedPrincipalsCommand to run as System.

- When sshd is run as system and provided username is system, run command as subprocess using posix_spawnp
- Improve debug logging in spawn_child_internal by providing different logging message for when CreateProcessW and CreateProcessAsUserW are called.

This is part 2 of the a 2 part PR to Fix issue #1546