### PR TITLE
Check if Powershell is running in admin mode before running script

### DIFF
--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -18,7 +18,7 @@ $sshagentpath = Join-Path $scriptdir "ssh-agent.exe"
 $etwman = Join-Path $scriptdir "openssh-events.man"
 
 if (-not (Test-Path $sshdpath)) {
-    throw "$sshdpath sshd.exe is not present in script path"
+    throw "sshd.exe is not present in script path"
 }
 
 if (Get-Service sshd -ErrorAction SilentlyContinue) 

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -3,6 +3,11 @@
 # @manojampalam - removed ntrights.exe dependency
 # @bingbing8 - removed secedit.exe dependency
 
+if (!([bool]([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")))
+{
+    throw "You must be running as an administrator, please restart as administrator"
+}
+
 $scriptpath = $MyInvocation.MyCommand.Path
 $scriptdir = Split-Path $scriptpath
 

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -3,6 +3,8 @@
 # @manojampalam - removed ntrights.exe dependency
 # @bingbing8 - removed secedit.exe dependency
 
+$ErrorActionPreference = 'Stop'
+
 if (!([bool]([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")))
 {
     throw "You must be running as an administrator, please restart as administrator"
@@ -16,7 +18,7 @@ $sshagentpath = Join-Path $scriptdir "ssh-agent.exe"
 $etwman = Join-Path $scriptdir "openssh-events.man"
 
 if (-not (Test-Path $sshdpath)) {
-    throw "sshd.exe is not present in script path"
+    throw "$sshdpath sshd.exe is not present in script path"
 }
 
 if (Get-Service sshd -ErrorAction SilentlyContinue) 
@@ -53,6 +55,7 @@ finally {
 }
 
 # Fix the registry permissions
+If ($PSVersiontable.PSVersion.Major -le 2) {$PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path}
 Import-Module $PSScriptRoot\OpenSSHUtils -Force
 Enable-Privilege SeRestorePrivilege | out-null
 

--- a/contrib/win32/openssh/uninstall-sshd.ps1
+++ b/contrib/win32/openssh/uninstall-sshd.ps1
@@ -1,4 +1,9 @@
-﻿$scriptpath = $MyInvocation.MyCommand.Path
+﻿if (!([bool]([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")))
+{
+    throw "You must be running as an administrator, please restart as administrator"
+}
+
+$scriptpath = $MyInvocation.MyCommand.Path
 $scriptdir = Split-Path $scriptpath
 $etwman = Join-Path $scriptdir "openssh-events.man"
 


### PR DESCRIPTION
Throws exception at the beginning of the script if Powershell is not running in admin mode. Change is compatible with Windows 7.
Fix: https://github.com/PowerShell/Win32-OpenSSH/issues/337