### PR TITLE
Windows shows UTF-16 characters correctly on the logs

### DIFF
--- a/log.c
+++ b/log.c
@@ -62,7 +62,7 @@ static void *log_handler_ctx;
 
 extern char *__progname;
 
-#define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL)
+#define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL|VIS_LOG_UTF16)
 #define LOG_STDERR_VIS	(VIS_SAFE|VIS_OCTAL)
 
 /* textual representation of log-facilities/levels */

--- a/log.c
+++ b/log.c
@@ -62,7 +62,12 @@ static void *log_handler_ctx;
 
 extern char *__progname;
 
+#ifdef WINDOWS
 #define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL|VIS_LOG_UTF16)
+#else
+#define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL)
+#endif
+
 #define LOG_STDERR_VIS	(VIS_SAFE|VIS_OCTAL)
 
 /* textual representation of log-facilities/levels */

--- a/openbsd-compat/vis.c
+++ b/openbsd-compat/vis.c
@@ -117,7 +117,7 @@ vis(char *dst, int c, int flag, int nextc)
 
 #ifdef WINDOWS
 	/*Avoid encoding UTF-16 chatacters so they 
-	  show up correctly on the logs*/
+	  show up correctly in the logs*/
 	if (flag & VIS_LOG_UTF16) {
 		*dst++ = c;
 		goto done;

--- a/openbsd-compat/vis.c
+++ b/openbsd-compat/vis.c
@@ -114,6 +114,16 @@ vis(char *dst, int c, int flag, int nextc)
 			goto done;
 		}
 	}
+
+#ifdef WINDOWS
+	/*Avoid encoding UTF-16 chatacters so they 
+	  show up correctly on the logs*/
+	if (flag & VIS_LOG_UTF16) {
+		*dst++ = c;
+		goto done;
+	}
+#endif 
+
 	if (((c & 0177) == ' ') || (flag & VIS_OCTAL) ||
 	    ((flag & VIS_GLOB) && (c == '*' || c == '?' || c == '[' || c == '#'))) {
 		*dst++ = '\\';

--- a/openbsd-compat/vis.h
+++ b/openbsd-compat/vis.h
@@ -81,10 +81,12 @@
  */
 #define	UNVIS_END	1	/* no more characters */
 
+#ifdef WINDOWS
 /*
  * UTF16 logs
  */
 #define VIS_LOG_UTF16	0x800
+#endif
 
 char	*vis(char *, int, int, int);
 int	strvis(char *, const char *, int);

--- a/openbsd-compat/vis.h
+++ b/openbsd-compat/vis.h
@@ -81,6 +81,11 @@
  */
 #define	UNVIS_END	1	/* no more characters */
 
+/*
+ * UTF16 logs
+ */
+#define VIS_LOG_UTF16	0x800
+
 char	*vis(char *, int, int, int);
 int	strvis(char *, const char *, int);
 int	stravis(char **, const char *, int);


### PR DESCRIPTION
Fix: https://github.com/PowerShell/Win32-OpenSSH/issues/1718

Logs with multi-byte characters are not being displayed correctly on both the log file and Event Viewer on Windows. 
E.g. In this scenario, a mkdir command is being executed to create a folder with russian characters over an sftp connection. This is how the logs were being displayed before the changes in this PR:
**sftp-server.log**
![git_logs_before_local](https://user-images.githubusercontent.com/81188381/115793292-dc859d80-a399-11eb-851b-6544483602f7.png)
**Event Viewer**
![git_logs_before_eventviewer](https://user-images.githubusercontent.com/81188381/115793310-e6a79c00-a399-11eb-9753-e85f139c4800.png)



This is how the logs are now displayed after the changes in this PR:

**sftp-server.log**
![git_logs_after_local](https://user-images.githubusercontent.com/81188381/115793458-266e8380-a39a-11eb-9b5d-83942d1bfaa7.png)
**Event Viewer**
![git_logs_after_eventviewer](https://user-images.githubusercontent.com/81188381/115793483-2ec6be80-a39a-11eb-8a93-e6856b49f502.png)

