### PR TITLE
Update _PATH_TTY to point to the console

### DIFF
--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -344,10 +344,12 @@ function Get-LocalUserProfile
         $askpass_util = Join-Path $Script:E2ETestDirectory "utilities\askpass_util\askpass_util.exe"
         $env:SSH_ASKPASS=$askpass_util
         $env:ASKPASS_PASSWORD=$OpenSSHTestAccountsPassword
+        $env:SSH_ASKPASS_REQUIRE="prefer"
         $ret = ssh -p 47002 "$User@localhost" echo %userprofile%
         if ($env:DISPLAY -eq 1) { Remove-Item env:\DISPLAY }
-        remove-item "env:SSH_ASKPASS" -ErrorAction SilentlyContinue
-        Remove-item "env:ASKPASS_PASSWORD" -ErrorAction SilentlyContinue 
+        Remove-item "env:SSH_ASKPASS" -ErrorAction SilentlyContinue
+        Remove-item "env:ASKPASS_PASSWORD" -ErrorAction SilentlyContinue
+        Remove-item "env:SSH_ASKPASS_REQUIRE" -ErrorAction SilentlyContinue
     }   
     
     (Get-ItemProperty -Path $userProfileRegistry -Name 'ProfileImagePath').ProfileImagePath    

--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -1715,3 +1715,4 @@
 #define HAVE_LOCALTIME_R
 #define HAVE_DECL_MEMMEM 0
 #define WITH_ZLIB
+#define _PATH_TTY "conin$"

--- a/regress/pesterTests/CommonUtils.psm1
+++ b/regress/pesterTests/CommonUtils.psm1
@@ -100,14 +100,16 @@ function Add-PasswordSetting
         $askpass_util = Join-Path $PSScriptRoot "utilities\askpass_util\askpass_util.exe"
         $env:SSH_ASKPASS=$askpass_util
         $env:ASKPASS_PASSWORD=$pass
+        $env:SSH_ASKPASS_REQUIRE="prefer"
     }
 }
 
 function Remove-PasswordSetting
 {
-    if ($env:DISPLAY -eq 1) { Remove-Item env:\DISPLAY }
+    if ($env:DISPLAY -eq 1) { Remove-Item env:\DISPLAY -ErrorAction SilentlyContinue }
     Remove-item "env:SSH_ASKPASS" -ErrorAction SilentlyContinue
     Remove-item "env:ASKPASS_PASSWORD" -ErrorAction SilentlyContinue
+    Remove-item "env:SSH_ASKPASS_REQUIRE" -ErrorAction SilentlyContinue
 }
 
 $Taskfolder = "\OpenSSHTestTasks\"


### PR DESCRIPTION
Original change - https://github.com/PowerShell/openssh-portable/pull/447

The right way to fix it is in config.h.vs file instead of defines.h


Credits to - @AJDurant, @LTRData