### PR TITLE
check_secure_file_permission: return error if get_sid() fails

### DIFF
--- a/contrib/win32/win32compat/w32-sshfileperm.c
+++ b/contrib/win32/win32compat/w32-sshfileperm.c
@@ -59,8 +59,10 @@ check_secure_file_permission(const char *input_path, struct passwd * pw, int rea
 	char *bad_user = NULL;
 	int ret = 0;
 
-	if ((user_sid = get_sid(pw ? pw->pw_name : NULL)) == NULL)
+	if ((user_sid = get_sid(pw ? pw->pw_name : NULL)) == NULL) {
+		ret = -1;
 		goto cleanup;
+	}
 
 	if ((path_utf16 = resolved_path_utf16(input_path)) == NULL) {
 		ret = -1;


### PR DESCRIPTION
check_secure_file_permission() currently returns success if get_sid() fails.