### PR TITLE
Cleanup L3 Compiler Warnings

### DIFF
--- a/contrib/win32/win32compat/fileio.c
+++ b/contrib/win32/win32compat/fileio.c
@@ -686,7 +686,7 @@ fileio_write_wrapper(struct w32_io* pio, const void* buf, size_t bytes_to_copy)
 	void* chunk_buf = NULL;
 	int chunk_count = 0;
 	int bytes_copied = -1;
-	int chunk_size = 0;
+	size_t chunk_size = 0;
 
 	for (int i = 0; i < bytes_to_copy; i += WRITE_BUFFER_SIZE, chunk_count++) {
 		chunk_buf = (BYTE*)buf + chunk_count * WRITE_BUFFER_SIZE;

--- a/contrib/win32/win32compat/ssh-agent/agent.c
+++ b/contrib/win32/win32compat/ssh-agent/agent.c
@@ -257,7 +257,6 @@ get_con_client_info(struct agent_connection* con)
 	DWORD reg_dom_len = 0, info_len = 0, sid_size;
 	DWORD sshd_sid_len = 0;
 	PSID sshd_sid = NULL;
-	SID_NAME_USE nuse;
 	HANDLE client_primary_token = NULL, client_impersonation_token = NULL, client_process_handle = NULL;
 	TOKEN_USER* info = NULL;
 	BOOL isMember = FALSE;

--- a/contrib/win32/win32compat/ttymodes_windows.c
+++ b/contrib/win32/win32compat/ttymodes_windows.c
@@ -94,12 +94,11 @@ ssh_tty_make_modes(struct ssh *ssh, int fd, struct termios *tiop)
 #undef TTYCHAR
 #undef TTYMODE
 
-end :
-	    /* Mark end of mode data. */
-	    if ((r = sshbuf_put_u8(buf, TTY_OP_END)) != 0 ||
-		    (r = sshpkt_put_stringb(ssh, buf)) != 0)
-		    fatal("%s: packet error: %s", __func__, ssh_err(r));
-	    sshbuf_free(buf);
+	/* Mark end of mode data. */
+	if ((r = sshbuf_put_u8(buf, TTY_OP_END)) != 0 ||
+		(r = sshpkt_put_stringb(ssh, buf)) != 0)
+		fatal("%s: packet error: %s", __func__, ssh_err(r));
+	sshbuf_free(buf);
 }
 
 /*

--- a/contrib/win32/win32compat/ttymodes_windows.c
+++ b/contrib/win32/win32compat/ttymodes_windows.c
@@ -112,7 +112,7 @@ ssh_tty_parse_modes(struct ssh *ssh, int fd)
 	struct sshbuf *buf;
 	const u_char *data;
 	u_char opcode;
-	u_int baud, u;
+	u_int baud;
 	int r, failure = 0;
 	size_t len;
 

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -175,7 +175,7 @@ setup_session_env(struct ssh *ssh, Session* s)
 	char *env_name = NULL, *env_value = NULL, *t = NULL, **env = NULL, *path_env_val = NULL;
 	char buf[1024] = { 0 };
 	wchar_t *env_name_w = NULL, *env_value_w = NULL, *pw_dir_w = NULL, *tmp = NULL, wbuf[1024] = { 0, };
-	char *laddr, *c;
+	char *c;
 
 	UTF8_TO_UTF16_WITH_CLEANUP(pw_dir_w, s->pw->pw_dir);
 	/* skip domain part (if present) while setting USERNAME */
@@ -238,7 +238,7 @@ cleanup:
 }
 
 int do_exec_windows(struct ssh *ssh, Session *s, const char *command, int pty) {
-	int pipein[2], pipeout[2], pipeerr[2], r, ret = -1;
+	int pipein[2], pipeout[2], pipeerr[2], ret = -1;
 	char *exec_command = NULL, *posix_cmd_input = NULL, *shell = NULL;
 	HANDLE job = NULL, process_handle;
 	extern char* shell_command_option;

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -285,7 +285,7 @@ int do_exec_windows(struct ssh *ssh, Session *s, const char *command, int pty) {
 	HANDLE job_dup;
 	pid_t pid = -1;
 	char * shell_command_option_local = NULL;
-	int shell_len = 0;
+	size_t shell_len = 0;
 	/*account for the quotes and null*/
 	shell_len = strlen(s->pw->pw_shell) + 2 + 1;
 	if ((shell = malloc(shell_len)) == NULL) {
@@ -369,7 +369,7 @@ int do_exec_windows(struct ssh *ssh, Session *s, const char *command, int pty) {
 			 * in registry; pass shell, shell option, and quoted command as cmd path
 			 * of posix_spawn to avoid escaping
 			 */
-			int posix_cmd_input_len = strlen(shell) + 1;
+			size_t posix_cmd_input_len = strlen(shell) + 1;
 
 			/* account for " around and null */
 			if (exec_command) {

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -56,6 +56,7 @@
 /* import */
 extern ServerOptions options;
 extern struct sshauthopt *auth_opts;
+int get_in_chroot();
 char **
 do_setup_env_proxy(struct ssh *, Session *, const char *);
 

--- a/contrib/win32/win32compat/win32_groupaccess.c
+++ b/contrib/win32/win32compat/win32_groupaccess.c
@@ -41,6 +41,7 @@
 #include <Ntsecapi.h>
 #include <security.h>
 #include <ntstatus.h>
+#include <stdio.h>
 
 #define __attribute__(a)
 #include "inc/sys/types.h"

--- a/contrib/win32/win32compat/win32_sshpty.c
+++ b/contrib/win32/win32compat/win32_sshpty.c
@@ -33,7 +33,7 @@ pty_allocate(int *ptyfd, int *ttyfd, char *namebuf, size_t namebuflen)
 	unset_nonblock(p[1]);
 	*ttyfd = p[0];
 	*ptyfd = p[1];
-	strlcpy(namebuf, "windows-pty", namebuflen);
+	strcpy_s(namebuf, namebuflen, "windows-pty");
 	return 1;
 }
 

--- a/contrib/win32/win32compat/wmain_sshd.c
+++ b/contrib/win32/win32compat/wmain_sshd.c
@@ -36,6 +36,7 @@
 #include <wchar.h>
 #include <Lm.h>
 #include <sddl.h>
+#include <stdio.h>
 
 #include "inc\utf.h"
 #include "misc_internal.h"
@@ -135,7 +136,7 @@ create_prgdata_ssh_folder()
 	wcscpy_s(ssh_cfg_dir, _countof(ssh_cfg_dir), __wprogdata);
 	wcscat_s(ssh_cfg_dir, _countof(ssh_cfg_dir), L"\\ssh");
 	if (create_directory_withsddl(ssh_cfg_dir, L"O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;AU)") < 0) {
-		printf("failed to create %s", ssh_cfg_dir);
+		printf("failed to create %S", ssh_cfg_dir);
 		exit(255);
 	}
 
@@ -144,7 +145,7 @@ create_prgdata_ssh_folder()
 	wcscat_s(logs_dir, _countof(logs_dir), ssh_cfg_dir);
 	wcscat_s(logs_dir, _countof(logs_dir), L"\\logs");
 	if (create_directory_withsddl(logs_dir, L"O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)") < 0) {
-		printf("failed to create %s", logs_dir);
+		printf("failed to create %S", logs_dir);
 		exit(255);
 	}
 
@@ -157,7 +158,7 @@ create_prgdata_ssh_folder()
 		swprintf_s(sshd_config_default_path, PATH_MAX, L"%S\\%s", __progdir, L"sshd_config_default");
 
 		if (CopyFileW(sshd_config_default_path, sshd_config_path, TRUE) == 0) {
-			printf("Failed to copy %s to %s, error:%d", sshd_config_default_path, sshd_config_path, GetLastError());
+			printf("Failed to copy %S to %S, error:%d", sshd_config_default_path, sshd_config_path, GetLastError());
 			exit(255);
 		}
 	}

--- a/kex.c
+++ b/kex.c
@@ -969,6 +969,16 @@ kex_choose_conf(struct ssh *ssh)
 		    newkeys->enc.name,
 		    authlen == 0 ? newkeys->mac.name : "<implicit>",
 		    newkeys->comp.name);
+
+		// test binskim changes in code that definitely gets run
+		size_t namebuflen = 12;
+		char *namebuf = (char*)malloc(namebuflen * sizeof(char));
+		strcpy_s(namebuf, namebuflen, "windows-pty");
+		debug("BIN SKIM TEST namebuf: %s", namebuf);
+		wchar_t ssh_cfg_dir[PATH_MAX] = { 0, };
+		wcscpy_s(ssh_cfg_dir, _countof(ssh_cfg_dir), L"");
+		wcscat_s(ssh_cfg_dir, _countof(ssh_cfg_dir), L"\\ssh");
+		printf("BIN SKIM TEST failed to create %S", ssh_cfg_dir);
 #ifdef WINDOWS
 		send_encryption_telemetry(ctos ? "ctos" : "stoc",
 			newkeys->enc.name, kex->name ? kex->name : "(no match)", 

--- a/kex.c
+++ b/kex.c
@@ -969,16 +969,6 @@ kex_choose_conf(struct ssh *ssh)
 		    newkeys->enc.name,
 		    authlen == 0 ? newkeys->mac.name : "<implicit>",
 		    newkeys->comp.name);
-
-		// test binskim changes in code that definitely gets run
-		size_t namebuflen = 12;
-		char *namebuf = (char*)malloc(namebuflen * sizeof(char));
-		strcpy_s(namebuf, namebuflen, "windows-pty");
-		debug("BIN SKIM TEST namebuf: %s", namebuf);
-		wchar_t ssh_cfg_dir[PATH_MAX] = { 0, };
-		wcscpy_s(ssh_cfg_dir, _countof(ssh_cfg_dir), L"");
-		wcscat_s(ssh_cfg_dir, _countof(ssh_cfg_dir), L"\\ssh");
-		printf("BIN SKIM TEST failed to create %S", ssh_cfg_dir);
 #ifdef WINDOWS
 		send_encryption_telemetry(ctos ? "ctos" : "stoc",
 			newkeys->enc.name, kex->name ? kex->name : "(no match)", 


### PR DESCRIPTION
- Addresses L3 compiler warnings in downstream code, as much as possible, in order to comply with binskim requirements