### PR TITLE
add connection status from sshd and remote protocol version to telemetry

### DIFF
--- a/auth2.c
+++ b/auth2.c
@@ -58,6 +58,9 @@
 #endif
 #include "monitor_wrap.h"
 #include "digest.h"
+#ifdef WINDOWS
+#include "sshTelemetry.h"
+#endif
 
 /* import */
 extern ServerOptions options;
@@ -432,6 +435,9 @@ userauth_finish(struct ssh *ssh, int authenticated, const char *method,
 		methods = authmethods_get(authctxt);
 		debug3_f("failure partial=%d next methods=\"%s\"",
 		    partial, methods);
+#ifdef WINDOWS
+		send_auth_method_telemetry(methods);
+#endif
 		if ((r = sshpkt_start(ssh, SSH2_MSG_USERAUTH_FAILURE)) != 0 ||
 		    (r = sshpkt_put_cstring(ssh, methods)) != 0 ||
 		    (r = sshpkt_put_u8(ssh, partial)) != 0 ||

--- a/contrib/win32/openssh/sshTelemetry.c
+++ b/contrib/win32/openssh/sshTelemetry.c
@@ -69,6 +69,19 @@ void send_auth_telemetry(const int status, const char* auth_type)
     TraceLoggingUnregister(g_hProvider1);
 }
 
+void send_auth_method_telemetry(const char* auth_methods)
+{
+    TraceLoggingRegister(g_hProvider1);
+    TraceLoggingWrite(
+        g_hProvider1,
+        "AuthMethods",
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+        TraceLoggingString(auth_methods, "authMethodsConfigured")
+    );
+    TraceLoggingUnregister(g_hProvider1);
+}
+
 void send_encryption_telemetry(const char* direction, 
     const char* cipher, const char* kex, const char* mac, 
     const char* comp, const char* host_key, 
@@ -164,49 +177,22 @@ void send_ssh_connection_telemetry(const char* conn, const char* port)
     TraceLoggingUnregister(g_hProvider1);
 }
 
-void send_sshd_config_telemetry(const int num_auth_methods, 
-    const char** auth_methods, const char* conn)
+void send_sshd_connection_telemetry(const char* conn)
 {
-    char* auth_buffer = NULL;
-    if (num_auth_methods == 0) {
-        auth_buffer = (char*)malloc(5 * sizeof(char));
-        strcpy_s(auth_buffer, 5, "none");
-    }
-    else {
-        // concatenate all the auth methods into a 
-        // single string to pass to tracelogging
-        size_t buffer_size = (size_t)num_auth_methods;
-        for (int i = 0; i < num_auth_methods; i++) {
-            buffer_size += strlen(auth_methods[i]);
-        }
-        auth_buffer = (char*)malloc((buffer_size + 1) * sizeof(char));
-        auth_buffer[0] = '\0';
-        for (int i = 0; i < num_auth_methods; i++) {
-            strcat_s(auth_buffer, buffer_size, auth_methods[i]);
-            if (i < num_auth_methods - 1) {
-                strcat_s(auth_buffer, buffer_size, ",");
-            }
-        }
-    }
     TraceLoggingRegister(g_hProvider1);
     TraceLoggingWrite(
         g_hProvider1,
         "SSHD",
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-        TraceLoggingString(auth_buffer, "authMethods"),
         TraceLoggingString(conn, "connStatus")
     );
     TraceLoggingUnregister(g_hProvider1);
-    free(auth_buffer);
 }
 
-void send_ssh_version_telemetry(const char* ssh_version, const char* peer_version,
-    const char* remote_protocol_supported, const int remote_major, const int remote_minor)
+void send_ssh_version_telemetry(const char* ssh_version, 
+    const char* peer_version, const char* remote_protocol_supported)
 {
-    // assuming digits of remote major & remote major won't exceed 4
-    char* remote_version = (char*)malloc(6 * sizeof(char));
-    sprintf_s(remote_version, 6, "%d.%d", remote_major, remote_minor);
     TraceLoggingRegister(g_hProvider1);
     TraceLoggingWrite(
         g_hProvider1,
@@ -215,10 +201,8 @@ void send_ssh_version_telemetry(const char* ssh_version, const char* peer_versio
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
         TraceLoggingString(ssh_version, "ourVersion"),
         TraceLoggingString(remote_protocol_supported, "remoteProtocolError"),
-        TraceLoggingString(peer_version, "peerVersion"),
-        TraceLoggingString(remote_version, "remoteVersion")
+        TraceLoggingString(peer_version, "peerVersion")
     );
     TraceLoggingUnregister(g_hProvider1);
-    free(remote_version);
 }
 

--- a/contrib/win32/openssh/sshTelemetry.c
+++ b/contrib/win32/openssh/sshTelemetry.c
@@ -191,7 +191,7 @@ void send_sshd_connection_telemetry(const char* conn)
 }
 
 void send_ssh_version_telemetry(const char* ssh_version, 
-    const char* peer_version, const char* remote_protocol_supported)
+    const char* peer_version, const char* remote_protocol_error)
 {
     TraceLoggingRegister(g_hProvider1);
     TraceLoggingWrite(
@@ -200,7 +200,7 @@ void send_ssh_version_telemetry(const char* ssh_version,
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
         TraceLoggingString(ssh_version, "ourVersion"),
-        TraceLoggingString(remote_protocol_supported, "remoteProtocolError"),
+        TraceLoggingString(remote_protocol_error, "remoteProtocolError"),
         TraceLoggingString(peer_version, "peerVersion")
     );
     TraceLoggingUnregister(g_hProvider1);

--- a/contrib/win32/openssh/sshTelemetry.c
+++ b/contrib/win32/openssh/sshTelemetry.c
@@ -165,7 +165,7 @@ void send_ssh_connection_telemetry(const char* conn, const char* port)
 }
 
 void send_sshd_config_telemetry(const int num_auth_methods, 
-    const char** auth_methods)
+    const char** auth_methods, const char* conn)
 {
     char* auth_buffer = NULL;
     if (num_auth_methods == 0) {
@@ -194,15 +194,19 @@ void send_sshd_config_telemetry(const int num_auth_methods,
         "SSHD",
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-        TraceLoggingString(auth_buffer, "authMethods")
+        TraceLoggingString(auth_buffer, "authMethods"),
+        TraceLoggingString(conn, "connStatus")
     );
     TraceLoggingUnregister(g_hProvider1);
     free(auth_buffer);
 }
 
 void send_ssh_version_telemetry(const char* ssh_version, const char* peer_version,
-    const char* remote_protocol_supported)
+    const char* remote_protocol_supported, const int remote_major, const int remote_minor)
 {
+    // assuming digits of remote major & remote major won't exceed 4
+    char* remote_version = (char*)malloc(6 * sizeof(char));
+    sprintf_s(remote_version, 6, "%d.%d", remote_major, remote_minor);
     TraceLoggingRegister(g_hProvider1);
     TraceLoggingWrite(
         g_hProvider1,
@@ -211,8 +215,10 @@ void send_ssh_version_telemetry(const char* ssh_version, const char* peer_versio
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
         TraceLoggingString(ssh_version, "ourVersion"),
         TraceLoggingString(remote_protocol_supported, "remoteProtocolError"),
-        TraceLoggingString(peer_version, "peerVersion")
+        TraceLoggingString(peer_version, "peerVersion"),
+        TraceLoggingString(remote_version, "remoteVersion")
     );
     TraceLoggingUnregister(g_hProvider1);
+    free(remote_version);
 }
 

--- a/contrib/win32/openssh/sshTelemetry.h
+++ b/contrib/win32/openssh/sshTelemetry.h
@@ -3,6 +3,9 @@
 // sends authentication type and status
 void send_auth_telemetry(const int status, const char* auth_type);
 
+// sends authentication methods configured by SSHD
+void send_auth_method_telemetry(const char* auth_methods);
+
 // sends crypto information like cipher, kex, and mac
 void send_encryption_telemetry(const char* direction, 
 	const char* cipher, const char* kex, const char* mac, 
@@ -21,11 +24,9 @@ void send_pubkey_sign_telemetry(const char* pubKeySignStatus);
 // sends connection status from ssh client
 void send_ssh_connection_telemetry(const char* conn, const char* port);
 
-// sends ports and auth methods configured by sshd
-void send_sshd_config_telemetry(const int num_auth_methods, 
-	const char** auth_methods, const char* conn);
+// sends connection status from ssh server
+void send_sshd_connection_telemetry(const char* conn);
 
 // sends version and peer version from ssh & sshd
 void send_ssh_version_telemetry(const char* ssh_version,
-	const char* peer_version, const char* remote_protocol_supported, 
-	const int remote_major, const int remote_minor);
+	const char* peer_version, const char* remote_protocol_supported);

--- a/contrib/win32/openssh/sshTelemetry.h
+++ b/contrib/win32/openssh/sshTelemetry.h
@@ -29,4 +29,4 @@ void send_sshd_connection_telemetry(const char* conn);
 
 // sends version and peer version from ssh & sshd
 void send_ssh_version_telemetry(const char* ssh_version,
-	const char* peer_version, const char* remote_protocol_supported);
+	const char* peer_version, const char* remote_protocol_error);

--- a/contrib/win32/openssh/sshTelemetry.h
+++ b/contrib/win32/openssh/sshTelemetry.h
@@ -23,8 +23,9 @@ void send_ssh_connection_telemetry(const char* conn, const char* port);
 
 // sends ports and auth methods configured by sshd
 void send_sshd_config_telemetry(const int num_auth_methods, 
-	const char** auth_methods);
+	const char** auth_methods, const char* conn);
 
 // sends version and peer version from ssh & sshd
 void send_ssh_version_telemetry(const char* ssh_version,
-	const char* peer_version, const char* remote_protocol_supported);
+	const char* peer_version, const char* remote_protocol_supported, 
+	const int remote_major, const int remote_minor);

--- a/kex.c
+++ b/kex.c
@@ -1333,8 +1333,7 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 		    peer_version_string);
 #ifdef WINDOWS
 		send_ssh_version_telemetry(our_version_string, peer_version_string,
-			"Bad remote protocol version identification", remote_major, 
-			remote_minor);
+			"Bad remote protocol version identification");
 #endif
 
  invalid:
@@ -1364,8 +1363,7 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 		send_error(ssh, "Protocol major versions differ.");
 #ifdef WINDOWS
 		send_ssh_version_telemetry(our_version_string, 
-			peer_version_string, "Protocol major versions differ",
-			remote_major, remote_minor);
+			peer_version_string, "Protocol major versions differ");
 #endif
 		r = SSH_ERR_NO_PROTOCOL_VERSION;
 		goto out;
@@ -1392,7 +1390,7 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 
 #ifdef WINDOWS
 	send_ssh_version_telemetry(our_version_string, 
-		peer_version_string, "none", remote_major, remote_minor);
+		peer_version_string, "none");
 #endif
 	/* success */
 	r = 0;

--- a/kex.c
+++ b/kex.c
@@ -1333,7 +1333,8 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 		    peer_version_string);
 #ifdef WINDOWS
 		send_ssh_version_telemetry(our_version_string, peer_version_string,
-			"Bad remote protocol version identification");
+			"Bad remote protocol version identification", remote_major, 
+			remote_minor);
 #endif
 
  invalid:
@@ -1363,7 +1364,8 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 		send_error(ssh, "Protocol major versions differ.");
 #ifdef WINDOWS
 		send_ssh_version_telemetry(our_version_string, 
-			peer_version_string, "Protocol major versions differ");
+			peer_version_string, "Protocol major versions differ",
+			remote_major, remote_minor);
 #endif
 		r = SSH_ERR_NO_PROTOCOL_VERSION;
 		goto out;
@@ -1390,7 +1392,7 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 
 #ifdef WINDOWS
 	send_ssh_version_telemetry(our_version_string, 
-		peer_version_string, "none");
+		peer_version_string, "none", remote_major, remote_minor);
 #endif
 	/* success */
 	r = 0;

--- a/sshd.c
+++ b/sshd.c
@@ -2600,8 +2600,8 @@ done_loading_hostkeys:
 	if ((ssh = ssh_packet_set_connection(NULL, sock_in, sock_out)) == NULL)
 #ifdef WINDOWS
 	{
-		send_sshd_config_telemetry(options.num_auth_methods,
-			options.auth_methods, "connection failed: unable to create connection");
+		send_sshd_connection_telemetry(
+			"connection failed: unable to create connection");
 		fatal("Unable to create connection");
 	}
 #else
@@ -2625,8 +2625,8 @@ done_loading_hostkeys:
 	if ((remote_port = ssh_remote_port(ssh)) < 0) {
 		debug("ssh_remote_port failed");
 #ifdef WINDOWS
-		send_sshd_config_telemetry(options.num_auth_methods,
-			options.auth_methods, "connection failed: ssh_remote_port failed");
+		send_sshd_connection_telemetry(
+			"connection failed: ssh_remote_port failed");
 #endif
 		cleanup_exit(255);
 	}
@@ -2659,8 +2659,7 @@ done_loading_hostkeys:
 	    rdomain == NULL ? "" : rdomain,
 	    rdomain == NULL ? "" : "\"");
 #ifdef WINDOWS
-	send_sshd_config_telemetry(options.num_auth_methods,
-		options.auth_methods, "connection established");
+	send_sshd_connection_telemetry("connection established");
 #endif
 	free(laddr);
 

--- a/sshd.c
+++ b/sshd.c
@@ -2230,10 +2230,6 @@ main(int ac, char **av)
 
 	debug("sshd version %s, %s", SSH_VERSION, SSH_OPENSSL_VERSION);
 
-#ifdef WINDOWS
-	send_sshd_config_telemetry(options.num_auth_methods, 
-		options.auth_methods);
-#endif
 	/* Store privilege separation user for later use if required. */
 	privsep_chroot = use_privsep && (getuid() == 0 || geteuid() == 0);
 	if ((privsep_pw = getpwnam(SSH_PRIVSEP_USER)) == NULL) {
@@ -2602,7 +2598,15 @@ done_loading_hostkeys:
 	io_sock_in = sock_in;
 	io_sock_out = sock_out;
 	if ((ssh = ssh_packet_set_connection(NULL, sock_in, sock_out)) == NULL)
+#ifdef WINDOWS
+	{
+		send_sshd_config_telemetry(options.num_auth_methods,
+			options.auth_methods, "connection failed: unable to create connection");
 		fatal("Unable to create connection");
+	}
+#else
+		fatal("Unable to create connection");
+#endif 
 	the_active_state = ssh;
 	ssh_packet_set_server(ssh);
 
@@ -2620,6 +2624,10 @@ done_loading_hostkeys:
 
 	if ((remote_port = ssh_remote_port(ssh)) < 0) {
 		debug("ssh_remote_port failed");
+#ifdef WINDOWS
+		send_sshd_config_telemetry(options.num_auth_methods,
+			options.auth_methods, "connection failed: ssh_remote_port failed");
+#endif
 		cleanup_exit(255);
 	}
 
@@ -2650,6 +2658,10 @@ done_loading_hostkeys:
 	    rdomain == NULL ? "" : " rdomain \"",
 	    rdomain == NULL ? "" : rdomain,
 	    rdomain == NULL ? "" : "\"");
+#ifdef WINDOWS
+	send_sshd_config_telemetry(options.num_auth_methods,
+		options.auth_methods, "connection established");
+#endif
 	free(laddr);
 
 	/*


### PR DESCRIPTION
- addition to telemetry: connection status (success/failure) from sshd
- modification to telemetry: sending auth methods configured by sshd from auth2.c instead of sshd.c (incorrect location)