### PR TITLE
fix folder permissions for programdata\ssh during server install

### DIFF
--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -367,7 +367,6 @@ function Repair-FilePermissionInternal {
         $caption = "Current owner: '$($acl.Owner)'. '$newOwner' should own '$FilePath'."
         $prompt = "Shall I set the file owner?"
         $description = "Set '$newOwner' as owner of '$FilePath'."
-        Write-Host "$caption $description $prompt" -ForegroundColor Yellow
         if($pscmdlet.ShouldProcess($description, $prompt, $caption))
         {
             Enable-Privilege SeRestorePrivilege | out-null

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -291,9 +291,9 @@ function Repair-SSHFolderPermission
     $logFolder = Join-Path $sshProgDataPath "logs"
     if (Test-Path $logFolder)
     {
-        Repair-FilePermission -FilePath $logFolder -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteOK $everyoneSid 
+        Repair-FilePermission -FilePath $logFolder -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteOK $everyoneSid, $authenticatedUserSid
         Get-ChildItem -Path $logFolder -Recurse -Force | ForEach-Object {
-            Repair-FilePermission -FilePath $_.FullName -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteOK $everyoneSid 
+            Repair-FilePermission -FilePath $_.FullName -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteOK $everyoneSid, $authenticatedUserSid 
         }
     }
 }

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -371,6 +371,7 @@ function Repair-FilePermissionInternal {
         $caption = "Current owner: '$($acl.Owner)'. '$newOwner' should own '$FilePath'."
         $prompt = "Shall I set the file owner?"
         $description = "Set '$newOwner' as owner of '$FilePath'."
+        Write-Host "$caption $description $prompt" -ForegroundColor Yellow
         if($pscmdlet.ShouldProcess($description, $prompt, $caption))
         {
             Enable-Privilege SeRestorePrivilege | out-null

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -43,6 +43,8 @@ $everyoneSid = Get-UserSID -WellKnownSidType ([System.Security.Principal.WellKno
 
 $currentUserSid = Get-UserSID -User "$($env:USERDOMAIN)\$($env:USERNAME)"
 
+$authenticatedUserSid = Get-UserSID -WellKnownSidType ([System.Security.Principal.WellKnownSidType]::AuthenticatedUserSid)
+
 #Taken from P/Invoke.NET with minor adjustments.
  $definition = @'
 using System;
@@ -220,6 +222,42 @@ function Repair-ModuliFilePermission
 
 <#
     .Synopsis
+    Repair-SshFolderFilePermission
+    Repair the file owner and Permission of ssh folder/files 
+#>
+
+function Repair-SshFolderFilePermission
+{
+    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="High")]
+    param (
+        [parameter(Mandatory=$true)]     
+        [ValidateNotNullOrEmpty()]     
+        [string]$FilePath) 
+
+        Repair-FilePermission -Owners $adminsSid -FullAccessNeeded $adminsSid,$systemSid -ReadAccessOK $authenticatedUserSid -ReadAccessNeeded $authenticatedUserSid @psBoundParameters       
+}
+
+<#
+    .Synopsis
+    Repair-PrivateKeyPermission
+    Repair the file owner and Permission of private keys in the ssh folder 
+#>
+
+function Repair-PrivateKeyPermission
+{
+    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="High")]
+    param (
+        [parameter(Mandatory=$true)]     
+        [ValidateNotNullOrEmpty()]     
+        [string]$FilePath) 
+
+        Repair-FilePermission -Owners $adminsSid -FullAccessNeeded $adminsSid,$systemSid @psBoundParameters      
+}
+
+
+
+<#
+    .Synopsis
     Repair-UserKeyPermission
     Repair the file owner and Permission of user config
     -FilePath: The path of the private user key
@@ -280,7 +318,7 @@ function Repair-FilePermission
         [System.Security.Principal.SecurityIdentifier[]] $ReadAccessNeeded = $null
     )
 
-    if(-not (Test-Path $FilePath -PathType Leaf))
+    if(-not (Test-Path $FilePath))
     {
         Write-host "$FilePath not found" -ForegroundColor Yellow
         return
@@ -726,4 +764,4 @@ function Enable-Privilege {
     $type[0]::EnablePrivilege($Privilege, $Disable)
 }
 
-Export-ModuleMember -Function Repair-FilePermission, Repair-SshdConfigPermission, Repair-SshdHostKeyPermission, Repair-AuthorizedKeyPermission, Repair-UserKeyPermission, Repair-UserSshConfigPermission, Enable-Privilege, Get-UserAccount, Get-UserSID, Repair-AdministratorsAuthorizedKeysPermission, Repair-ModuliFilePermission
+Export-ModuleMember -Function Repair-FilePermission, Repair-SshdConfigPermission, Repair-SshdHostKeyPermission, Repair-AuthorizedKeyPermission, Repair-UserKeyPermission, Repair-UserSshConfigPermission, Enable-Privilege, Get-UserAccount, Get-UserSID, Repair-AdministratorsAuthorizedKeysPermission, Repair-ModuliFilePermission, Repair-SshFolderFilePermission, Repair-PrivateKeyPermission

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -277,24 +277,15 @@ function Repair-SSHFolderPermission
 
     # SSH Folder - owner: System or Admins; full access: System, Admins; read or readandexecute/synchronize permissible: Authenticated Users
     Repair-FilePermission -FilePath $sshProgDataPath -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid,$systemSid -ReadAndExecuteAccessOK $authenticatedUserSid
-    # Files in SSH Folder (excluding private key & log files) 
+    # Files in SSH Folder (excluding private key files) 
     # owner: System or Admins; full access: System, Admins; read/readandexecute/synchronize permissable: Authenticated Users
     $privateKeyFiles = @("ssh_host_dsa_key", "ssh_host_ecdsa_key", "ssh_host_ed25519_key", "ssh_host_rsa_key")
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Exclude ($privateKeyFiles + "*.log") -File -Force | ForEach-Object {
+    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Exclude ($privateKeyFiles) -Force | ForEach-Object {
         Repair-FilePermission -FilePath $_.FullName -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteAccessOK $authenticatedUserSid
     } 
-    # Private key files - owner: System or Admins; full access: System, Admins; 
+    # Private key files - owner: System or Admins; full access: System, Admins
     Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include $privateKeyFiles -Force | ForEach-Object {
         Repair-FilePermission -FilePath $_.FullName -Owners $adminsSid, $systemSid -FullAccessNeeded $systemSid, $adminsSid
-    }
-    # Log folder/files - owner: System or Admins; full access: System, Admins; read or readandexecute/synchronize permissible: any user
-    $logFolder = Join-Path $sshProgDataPath "logs"
-    if (Test-Path $logFolder)
-    {
-        Repair-FilePermission -FilePath $logFolder -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteAccessOK $everyoneSid, $authenticatedUserSid
-        Get-ChildItem -Path $logFolder -Recurse -Force | ForEach-Object {
-            Repair-FilePermission -FilePath $_.FullName -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteAccessOK $everyoneSid, $authenticatedUserSid 
-        }
     }
 }
 

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -85,25 +85,30 @@ if (Test-Path $moduliPath -PathType Leaf)
     Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters -confirm:$false
 }
 
-#If %programData%/ssh folder already exists, verify permissions and fix, if necessary
-$sshProgDataPath = Join-Path $env:ProgramData "sshTest"
+# If %programData%/ssh folder already exists, verify permissions and fix, if necessary
+$sshProgDataPath = Join-Path $env:ProgramData "ssh"
 if (Test-Path $sshProgDataPath)
 {
     # Folder permission is FullAccess to System and Builtin/Admins and read only access to Authenticated users, if user allows
     Repair-SshFolderFilePermission -FilePath $sshProgDataPath @psBoundParameters
-    # All files besides private key files and log folder/files should have same permissions as ssh folder, if user allows
-    $restricted_files = @("ssh_host_dsa_key", "ssh_host_ecdsa_key", "ssh_host_ed25519_key", "ssh_host_rsa_key", "*.logs")
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Exclude $restricted_files -File -Force | ForEach-Object {
+    # All files besides private key files and log folder should have same permissions as ssh folder, if user allows
+    $privateKeyFiles = @("ssh_host_dsa_key", "ssh_host_ecdsa_key", "ssh_host_ed25519_key", "ssh_host_rsa_key")
+    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Exclude ($privateKeyFiles + "*.log") -File -Force | ForEach-Object {
         Repair-SshFolderFilePermission -FilePath $_.FullName @psBoundParameters
     } 
-    # private key files and log folder/files should only allow FullAccess to System and Builtin/Admins, if user allows 
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include $restricted_files -File -Force | ForEach-Object {
+    # Private key files should only allow FullAccess to System and Builtin/Admins, if user allows 
+    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include $privateKeyFiles -Force | ForEach-Object {
         Repair-PrivateKeyPermission -FilePath $_.FullName @psBoundParameters
     }
+    # Log folder and log files created by sshd only allow FullAccess to System and Buildin/Admins, 
+    # However if read access has been added for other users, that is ok
     $logFolder = Join-Path $sshProgDataPath "logs"
     if (Test-Path $logFolder)
     {
-        Repair-PrivateKeyPermission -FilePath $logFolder @psBoundParameters
+        Repair-ModuliFilePermission -FilePath $logFolder @psBoundParameters
+        Get-ChildItem -Path $logFolder -Recurse -Force | ForEach-Object {
+            Repair-ModuliFilePermission -FilePath $_.FullName @psBoundParameters
+        }
     }
 }
 

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -85,31 +85,11 @@ if (Test-Path $moduliPath -PathType Leaf)
     Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters -confirm:$false
 }
 
-# If %programData%/ssh folder already exists, verify permissions and fix, if necessary
+# If %programData%/ssh folder already exists, verify and, if necessary and approved by user, fix permissions 
 $sshProgDataPath = Join-Path $env:ProgramData "ssh"
 if (Test-Path $sshProgDataPath)
 {
-    # Folder permission is FullAccess to System and Builtin/Admins and read only access to Authenticated users, if user allows
-    Repair-SshFolderFilePermission -FilePath $sshProgDataPath @psBoundParameters
-    # All files besides private key files and log folder should have same permissions as ssh folder, if user allows
-    $privateKeyFiles = @("ssh_host_dsa_key", "ssh_host_ecdsa_key", "ssh_host_ed25519_key", "ssh_host_rsa_key")
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Exclude ($privateKeyFiles + "*.log") -File -Force | ForEach-Object {
-        Repair-SshFolderFilePermission -FilePath $_.FullName @psBoundParameters
-    } 
-    # Private key files should only allow FullAccess to System and Builtin/Admins, if user allows 
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include $privateKeyFiles -Force | ForEach-Object {
-        Repair-PrivateKeyPermission -FilePath $_.FullName @psBoundParameters
-    }
-    # Log folder and log files created by sshd only allow FullAccess to System and Buildin/Admins, 
-    # However if read access has been added for other users, that is ok
-    $logFolder = Join-Path $sshProgDataPath "logs"
-    if (Test-Path $logFolder)
-    {
-        Repair-ModuliFilePermission -FilePath $logFolder @psBoundParameters
-        Get-ChildItem -Path $logFolder -Recurse -Force | ForEach-Object {
-            Repair-ModuliFilePermission -FilePath $_.FullName @psBoundParameters
-        }
-    }
+    Repair-SSHFolderPermission -sshProgDataPath $sshProgDataPath
 }
 
 #register etw provider

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -93,9 +93,16 @@ if (Test-Path $sshProgDataPath)
     # Folder permission is FullAccess to System and Builtin/Admins and read only access to Authenticated users
     $sshProgDataAcl.SetSecurityDescriptorSddlForm("O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;AU)")
     Set-Acl $sshProgDataPath $sshProgDataAcl
-    # key files should only allow FullAccess to System and Builtin/Admins
+    # private key files and log folder/files should only allow FullAccess to System and Builtin/Admins
+    $restricted_files = @("ssh_host_dsa_key", "ssh_host_ecdsa_key", "ssh_host_ed25519_key", "ssh_host_rsa_key")
+    $sshProgDataAcl.SetSecurityDescriptorSddlForm("O:BAD:PAI(A;;FA;;;SY)(A;;FA;;;BA)")
+    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include $restricted_files -Force | Set-Acl -AclObject $sshProgDataAcl
     $sshProgDataAcl.SetSecurityDescriptorSddlForm("O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include "*key*" -Force | Set-Acl -AclObject $sshProgDataAcl
+    $log_folder = Join-Path $sshProgDataPath "logs"
+    if (Test-Path $log_folder)
+    {
+        Set-Acl $log_folder $sshProgDataAcl 
+    }
 }
 
 #register etw provider


### PR DESCRIPTION
https://github.com/PowerShell/Win32-OpenSSH/issues/1900

- During sshd install, if ssh folder already exists, set permissions to the same settings as when folder is initially created in wmain_sshd.c. Essentially, ensure folder and any existing files, with few exceptions, are set to these permissions: owner: System or Admins; full access: System, Admins; read or readandexecute/synchronize: Authenticated Users
- Any existing private key files are given the following permissions: owner: System or Admins; full access: System, Admins