### PR TITLE
ssh-sk-helper: check RP ID and signed message contents

### DIFF
--- a/ssh-sk-helper.c
+++ b/ssh-sk-helper.c
@@ -112,10 +112,20 @@ process_sign(struct sshbuf *req)
 
 	if ((r = sshkey_private_deserialize(kbuf, &key)) != 0)
 		fatal_r(r, "%s: Unable to parse private key", __progname);
+#ifndef WINDOWS
 	if (!sshkey_is_sk(key)) {
 		fatal("%s: Unsupported key type %s",
 		    __progname, sshkey_ssh_name(key));
 	}
+#else
+	if (!sshkey_is_sk(key) || key->sk_application == NULL) {
+		fatal("%s: Unsupported key type %s",
+		    __progname, sshkey_ssh_name(key));
+	}
+	if (strncmp(key->sk_application, "ssh:", 4) != 0) {
+		fatal("%s: web-origin key", __progname);
+	}
+#endif
 
 	debug_f("ready to sign with key %s, provider %s: "
 	    "msg len %zu, compat 0x%lx", sshkey_type(key),
@@ -174,6 +184,10 @@ process_enroll(struct sshbuf *req)
 
 	if (type > INT_MAX)
 		fatal("%s: bad type %u", __progname, type);
+#ifdef WINDOWS
+	if (application == NULL || strncmp(application, "ssh:", 4) != 0)
+		fatal("%s: bogus application", __progname);
+#endif
 	if (sshbuf_len(challenge) == 0) {
 		sshbuf_free(challenge);
 		challenge = NULL;
@@ -246,6 +260,11 @@ process_load_resident(struct sshbuf *req)
 		fatal_r(r, "%s: compose", __progname);
 
 	for (i = 0; i < nkeys; i++) {
+#ifdef WINDOWS
+		if (keys[i]->sk_application == NULL ||
+		    strncmp(keys[i]->sk_application, "ssh:", 4) != 0)
+			fatal("%s: non-ssh application", __progname);
+#endif
 		debug_f("key %zu %s %s", i, sshkey_type(keys[i]),
 		    keys[i]->sk_application);
 		sshbuf_reset(kbuf);


### PR DESCRIPTION
ssh-sk-helper performs operations on a FIDO token according to instructions received on stdin. It accepts 3 different request types: `SSH_SK_HELPER_SIGN`, `SSH_SK_HELPER_ENROLL`, and `SSH_SK_HELPER_LOAD_RESIDENT`. `SSH_SK_HELPER_LOAD_RESIDENT` requires CTAP 2.1 credential management and is not supported on Windows.

This PR ensures that:

- for `SSH_SK_HELPER_ENROLL` requests, the application to which the generated credential is scoped starts with "ssh:";
- for `SSH_SK_HELPER_SIGN` requests, the application to which the signature is scoped starts with "ssh:".