### PR TITLE
detect add-type edge case with powershell 7

### DIFF
--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -95,7 +95,15 @@ public class AdjPriv
 }
 '@
  
-$type = Add-Type $definition -PassThru -ErrorAction SilentlyContinue
+try
+{
+    $type = Add-Type $definition -PassThru -ErrorAction SilentlyContinue
+}
+catch
+{
+    # Powershell 7 does not add a type if it already exists
+    $type = [AdjPriv]
+}
 
 <#
     .Synopsis


### PR DESCRIPTION
- With PowerShell 7, Add-Type does not add a type if it already exists in the session, resulting in an empty $type variable. 
- Adds detection for the above scenario, and manually sets $type to [AdjPriv], if necessary.  