### PR TITLE
bump LibreSSL to 3.4.2.0 and fetch libfido2 from developers.yubico.com

### DIFF
--- a/contrib/win32/openssh/GetFIDO2.ps1
+++ b/contrib/win32/openssh/GetFIDO2.ps1
@@ -36,7 +36,7 @@ Write-Host "override:$override"
 
 $zip_path = Join-Path $PSScriptRoot "libfido2.zip"
 
-$release_url = "https://ambientworks.net/tmp/libfido2-1.10-b32020cc-win.zip"
+$release_url = "https://developers.yubico.com/libfido2/Releases/libfido2-$version-win.zip"
 Write-Host "release_url:$release_url"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor `
@@ -57,7 +57,7 @@ if($e -ne $null)
     throw "Error when expand zip file. libfido2 version:$version"
 }
 
-Rename-Item -Path $destDir\libfido2-1.10-b32020cc-win -NewName libfido2
+Rename-Item -Path $destDir\libfido2-$version-win -NewName libfido2
 Remove-Item $zip_path -Force -ErrorAction SilentlyContinue
 
 Write-Host "Succesfully downloaded libfido2 version:$version"

--- a/contrib/win32/openssh/paths.targets
+++ b/contrib/win32/openssh/paths.targets
@@ -4,7 +4,7 @@
     <OpenSSH-Src-Path>$(SolutionDir)..\..\..\</OpenSSH-Src-Path>
     <OpenSSH-Bin-Path>$(SolutionDir)..\..\..\bin\</OpenSSH-Bin-Path>
     <OpenSSH-Lib-Path>$(SolutionDir)lib\</OpenSSH-Lib-Path>
-    <LibreSSLVersion>3.3.3.0</LibreSSLVersion>
+    <LibreSSLVersion>3.4.2.0</LibreSSLVersion>
     <ZLibVersion>1.2.11</ZLibVersion>
     <fido2Version>1.9.0</fido2Version>
     <LibreSSL-Path>$(SolutionDir)\LibreSSL\sdk\</LibreSSL-Path>

--- a/contrib/win32/openssh/paths.targets
+++ b/contrib/win32/openssh/paths.targets
@@ -6,7 +6,7 @@
     <OpenSSH-Lib-Path>$(SolutionDir)lib\</OpenSSH-Lib-Path>
     <LibreSSLVersion>3.4.2.0</LibreSSLVersion>
     <ZLibVersion>1.2.11</ZLibVersion>
-    <fido2Version>1.9.0</fido2Version>
+    <fido2Version>1.10.0</fido2Version>
     <LibreSSL-Path>$(SolutionDir)\LibreSSL\sdk\</LibreSSL-Path>
     <LibreSSL-x86-Path>$(SolutionDir)\LibreSSL\bin\desktop\x86\</LibreSSL-x86-Path>
     <LibreSSL-x64-Path>$(SolutionDir)\LibreSSL\bin\desktop\x64\</LibreSSL-x64-Path>


### PR DESCRIPTION
While a build of PowerShell/libfido2 is worked on, point GetFIDO2.ps1 at libfido2's official Windows release. This is possible now that PowerShell/LibreSSL 3.4.2.0 was released.