### PR TITLE
Switch to use MS mirror of libfido2

### DIFF
--- a/contrib/win32/openssh/GetFIDO2.ps1
+++ b/contrib/win32/openssh/GetFIDO2.ps1
@@ -36,7 +36,7 @@ Write-Host "override:$override"
 
 $zip_path = Join-Path $PSScriptRoot "libfido2.zip"
 
-$release_url = "https://developers.yubico.com/libfido2/Releases/libfido2-$version-win.zip"
+$release_url = "https://github.com/PowerShell/libfido2/releases/download/$version/libfido2.zip"
 Write-Host "release_url:$release_url"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor `
@@ -51,13 +51,12 @@ if(-not (Test-Path $zip_path))
 }
 
 # XXX check pgp sig?
-Expand-Archive -Path $zip_path -DestinationPath $destDir -Force -ErrorAction SilentlyContinue -ErrorVariable e
+Expand-Archive -Path $zip_path -DestinationPath $destDir\libfido2 -Force -ErrorAction SilentlyContinue -ErrorVariable e
 if($e -ne $null)
 {
     throw "Error when expand zip file. libfido2 version:$version"
 }
 
-Rename-Item -Path $destDir\libfido2-$version-win -NewName libfido2
 Remove-Item $zip_path -Force -ErrorAction SilentlyContinue
 
 Write-Host "Succesfully downloaded libfido2 version:$version"

--- a/contrib/win32/openssh/paths.targets
+++ b/contrib/win32/openssh/paths.targets
@@ -13,10 +13,10 @@
     <LibreSSL-arm64-Path>$(SolutionDir)\LibreSSL\bin\desktop\arm64\</LibreSSL-arm64-Path>
     <LibreSSL-arm-Path>$(SolutionDir)\LibreSSL\bin\desktop\arm\</LibreSSL-arm-Path>
     <fido2-Path>$(SolutionDir)\libfido2\</fido2-Path>
-    <fido2-x86-Path>$(SolutionDir)\libfido2\Win32\Release\v143\static\</fido2-x86-Path>
-    <fido2-x64-Path>$(SolutionDir)\libfido2\Win64\Release\v143\static\</fido2-x64-Path>
-    <fido2-arm64-Path>$(SolutionDir)\libfido2\ARM64\Release\v143\static\</fido2-arm64-Path>
-    <fido2-arm-Path>$(SolutionDir)\libfido2\ARM\Release\v143\static\</fido2-arm-Path>
+    <fido2-x86-Path>$(SolutionDir)\libfido2\Win32\Release\static\</fido2-x86-Path>
+    <fido2-x64-Path>$(SolutionDir)\libfido2\Win64\Release\static\</fido2-x64-Path>
+    <fido2-arm64-Path>$(SolutionDir)\libfido2\ARM64\Release\static\</fido2-arm64-Path>
+    <fido2-arm-Path>$(SolutionDir)\libfido2\ARM\Release\static\</fido2-arm-Path>
     <ZLib-Path>$(SolutionDir)\ZLib\sdk\</ZLib-Path>
     <ZLib-x86-Path>$(SolutionDir)\ZLib\bin\x86\</ZLib-x86-Path>
     <ZLib-x64-Path>$(SolutionDir)\ZLib\bin\x64\</ZLib-x64-Path>


### PR DESCRIPTION
Changing to use `PowerShell/libfido2` releases.
These changes were tried and successfully built on both internal build pipelines.