### PR TITLE
Fix SCP stack overflow when copying over directories

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -1279,9 +1279,9 @@ source(int argc, char **argv)
 				encname = xmalloc(len + 1);
 				encname_len = len + 1;
 			}
-			while (tmp_len = strnvis(encname, name, encname_len, VIS_NL) > encname_len) {
+			while (tmp_len = strnvis(encname, name, encname_len, VIS_NL) >= encname_len) {
 				// check if tmp_len is less than MAX_PATH?
-				encname = xrealloc(encname, tmp_len + 1);
+				encname = xreallocarray(encname, tmp_len + 1, sizeof(char));
 				encname_len = tmp_len;
 			}
 			name = encname;
@@ -1323,7 +1323,7 @@ syserr:			run_err("%s: %s", name, strerror(errno));
 		while (tmp_len = snprintf(buf, sizeof buf, "C%04o %lld %s\n",
 		      (u_int) (stb.st_mode & FILEMODEMASK),
 			  (long long)stb.st_size, last) >= buf_len) {
-			buf = xrealloc(buf, tmp_len + 1);
+			buf = xreallocarray(buf, tmp_len + 1, sizeof(char));
 			buf_len = tmp_len + 1;
 		}
 		if (verbose_mode)
@@ -1411,7 +1411,7 @@ rsource(char *name, struct stat *statp)
 
 	while (len = snprintf(path, sizeof path, "D%04o %d %.1024s\n",
 		  (u_int)(statp->st_mode & FILEMODEMASK), 0, last) >= path_len) {
-		path = xrealloc(path, len + 1);
+		path = xreallocarray(path, len + 1, sizeof(char));
 		path_len = len + 1;
 	}
 
@@ -1434,7 +1434,7 @@ rsource(char *name, struct stat *statp)
 		(void) snprintf(path, sizeof path, "%s/%s", name, dp->d_name);
 
 		while (len = snprintf(path, sizeof path, "%s/%s", name, dp->d_name) >= path_len) {
-			path = xrealloc(path, len + 1);
+			path = xreallocarray(path, len + 1, sizeof(char));
 			path_len = len + 1;
 		}
 

--- a/scp.c
+++ b/scp.c
@@ -1344,7 +1344,7 @@ syserr:			run_err("%s: %s", name, strerror(errno));
 		}
 #else
 		snprintf(buf, sizeof buf, "C%04o %lld %s\n",
-		    (u_int)(stb.st_mode & FILEMODEMASK),
+		    (u_int) (stb.st_mode & FILEMODEMASK),
 		    (long long)stb.st_size, last);
 #endif
 		if (verbose_mode)
@@ -1446,8 +1446,8 @@ rsource(char *name, struct stat *statp)
 		path_len = len + 1;
 	}
 #else
-	(void)snprintf(path, sizeof path, "D%04o %d %.1024s\n",
-	    (u_int)(statp->st_mode & FILEMODEMASK), 0, last);
+	(void) snprintf(path, sizeof path, "D%04o %d %.1024s\n",
+	    (u_int) (statp->st_mode & FILEMODEMASK), 0, last);
 #endif
 	if (verbose_mode)
 		fmprintf(stderr, "Entering directory: %s", path);

--- a/scp.c
+++ b/scp.c
@@ -1271,7 +1271,6 @@ source(int argc, char **argv)
 	char *last, *name, buf[PATH_MAX + 128], encname[PATH_MAX];
 #endif
 	int len;
-	
 
 	for (indx = 0; indx < argc; ++indx) {
 		name = argv[indx];
@@ -1281,7 +1280,6 @@ source(int argc, char **argv)
 			name[--len] = '\0';
 		if ((fd = open(name, O_RDONLY|O_NONBLOCK, 0)) == -1)
 			goto syserr;
-
 		if (strchr(name, '\n') != NULL) {
 #ifdef WINDOWS
 			if (!encname) {

--- a/scp.c
+++ b/scp.c
@@ -1285,11 +1285,11 @@ source(int argc, char **argv)
 		if (strchr(name, '\n') != NULL) {
 #ifdef WINDOWS
 			if (!encname) {
-				encname_len = ((2 * len) < MAX_PATH) ? 2 * len : MAX_PATH;
+				encname_len = ((2 * len) < PATH_MAX) ? 2 * len : PATH_MAX;
 				encname = xmalloc(encname_len);
 			}
 			while ((tmp_len = strnvis(encname, name, encname_len, VIS_NL)) >= encname_len) {
-				if (tmp_len >= MAX_PATH)
+				if (tmp_len >= PATH_MAX)
 					break;
 				encname = xreallocarray(encname, tmp_len + 1, sizeof(char));
 				encname_len = tmp_len + 1;
@@ -1332,15 +1332,15 @@ syserr:			run_err("%s: %s", name, strerror(errno));
 		}
 #define	FILEMODEMASK	(S_ISUID|S_ISGID|S_IRWXU|S_IRWXG|S_IRWXO)
 #ifdef WINDOWS
-		buf_len = ((strlen(last) + 20) < MAX_PATH) ? strlen(last) + 20 : MAX_PATH;
+		buf_len = ((strlen(last) + 20) < PATH_MAX) ? strlen(last) + 20 : PATH_MAX;
 		buf = xmalloc(buf_len);
 		while ((tmp_len = snprintf(buf, buf_len, "C%04o %lld %s\n",
 		      (u_int) (stb.st_mode & FILEMODEMASK),
 			  (long long)stb.st_size, last)) >= buf_len) {
-			if (tmp_len >= MAX_PATH)
+			if (tmp_len >= PATH_MAX)
 				break;
-			buf = xreallocarray(buf, tmp_len + 1, sizeof(char));
 			buf_len = tmp_len + 1;
+			buf = xreallocarray(buf, buf_len, sizeof(char));
 		}
 #else
 		snprintf(buf, sizeof buf, "C%04o %lld %s\n",
@@ -1439,11 +1439,12 @@ rsource(char *name, struct stat *statp)
 	}
 #ifdef WINDOWS
 	while ((len = snprintf(path, path_len, "D%04o %d %.1024s\n",
-		  (u_int)(statp->st_mode & FILEMODEMASK), 0, last)) >= path_len) {
-		if (len >= MAX_PATH)
+		  (u_int)(statp->st_mode & FILEMODEMASK), 0, last)) >= path_len)
+	{
+		if (len >= PATH_MAX)
 			break;
-		path = xreallocarray(path, len + 1, sizeof(char));
 		path_len = len + 1;
+		path = xreallocarray(path, path_len, sizeof(char));
 	}
 #else
 	(void) snprintf(path, sizeof path, "D%04o %d %.1024s\n",
@@ -1471,8 +1472,8 @@ rsource(char *name, struct stat *statp)
 		}
 #ifdef WINDOWS
 		while ((len = snprintf(path, path_len, "%s/%s", name, dp->d_name)) >= path_len) {
-			path = xreallocarray(path, len + 1, sizeof(char));
 			path_len = len + 1;
+			path = xreallocarray(path, path_len, sizeof(char));
 		}
 #else
 		(void) snprintf(path, sizeof path, "%s/%s", name, dp->d_name);

--- a/scp.c
+++ b/scp.c
@@ -1334,6 +1334,8 @@ syserr:			run_err("%s: %s", name, strerror(errno));
 #ifdef WINDOWS
 		if (!buf) 
 		{
+			/*Set the initial size of buf to "strlen(last) + 20" based on multiple tests that*/
+			/*inidicate that this is usually enough. If not enough, more space will be allocated below.*/
 			buf_len = ((strlen(last) + 20) < PATH_MAX) ? strlen(last) + 20 : PATH_MAX;
 			buf = xmalloc(buf_len);
 		}

--- a/scp.c
+++ b/scp.c
@@ -1453,17 +1453,22 @@ rsource(char *name, struct stat *statp)
 			continue;
 		if (!strcmp(dp->d_name, ".") || !strcmp(dp->d_name, ".."))
 			continue;
+#ifdef WINDOWS
 		if (strlen(name) + 1 + strlen(dp->d_name) >= PATH_MAX - 1) {
+#else 
+		if (strlen(name) + 1 + strlen(dp->d_name) >= sizeof(path) - 1) {
+#endif
 			run_err("%s/%s: name too long", name, dp->d_name);
 			continue;
 		}
-		(void) snprintf(path, sizeof path, "%s/%s", name, dp->d_name);
-
+#ifdef WINDOWS
 		while (len = snprintf(path, sizeof path, "%s/%s", name, dp->d_name) >= path_len) {
 			path = xreallocarray(path, len + 1, sizeof(char));
 			path_len = len + 1;
 		}
-
+#else
+		(void) snprintf(path, sizeof path, "%s/%s", name, dp->d_name);
+#endif
 		vect[0] = path;
 		source(1, vect);
 	}

--- a/scp.c
+++ b/scp.c
@@ -1291,8 +1291,8 @@ source(int argc, char **argv)
 			while ((tmp_len = strnvis(encname, name, encname_len, VIS_NL)) >= encname_len) {
 				if (tmp_len >= PATH_MAX)
 					break;
-				encname = xreallocarray(encname, tmp_len + 1, sizeof(char));
 				encname_len = tmp_len + 1;
+				encname = xreallocarray(encname, encname_len, sizeof(char));
 			}
 #else
 			strnvis(encname, name, sizeof(encname), VIS_NL);
@@ -1332,8 +1332,11 @@ syserr:			run_err("%s: %s", name, strerror(errno));
 		}
 #define	FILEMODEMASK	(S_ISUID|S_ISGID|S_IRWXU|S_IRWXG|S_IRWXO)
 #ifdef WINDOWS
-		buf_len = ((strlen(last) + 20) < PATH_MAX) ? strlen(last) + 20 : PATH_MAX;
-		buf = xmalloc(buf_len);
+		if (!buf) 
+		{
+			buf_len = ((strlen(last) + 20) < PATH_MAX) ? strlen(last) + 20 : PATH_MAX;
+			buf = xmalloc(buf_len);
+		}
 		while ((tmp_len = snprintf(buf, buf_len, "C%04o %lld %s\n",
 		      (u_int) (stb.st_mode & FILEMODEMASK),
 			  (long long)stb.st_size, last)) >= buf_len) {


### PR DESCRIPTION
Fix: https://github.com/PowerShell/Win32-OpenSSH/issues/1897

"SCP -r <source>...<target>" causes a stack overflow when "source" is deeper than a certain number of levels. That is caused because the stack frames for the source and rsource functions, which are called recursively, are too large due to local arrays of size PATH_MAX (defined as 32768 in Win32-OpenSSH). That problem is mitigated by this PR by dynamically allocating memory instead of declaring those arrays with such a large size.