### PR TITLE
Update install sshd

### DIFF
--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -273,7 +273,7 @@ function Repair-UserSshConfigPermission
 <#
     .Synopsis
     Repair-SSHFolderPermission
-    Repair the file owner and permission of ssh folder & any files inside it
+    Repair the file owner and permission of ProgramData\ssh folder
 #>
 function Repair-SSHFolderPermission
 {
@@ -281,20 +281,44 @@ function Repair-SSHFolderPermission
     param (
         [parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]        
-        [string]$sshProgDataPath)
+        [string]$FilePath)
 
     # SSH Folder - owner: System or Admins; full access: System, Admins; read or readandexecute/synchronize permissible: Authenticated Users
-    Repair-FilePermission -FilePath $sshProgDataPath -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid,$systemSid -ReadAndExecuteAccessOK $authenticatedUserSid
-    # Files in SSH Folder (excluding private key files) 
-    # owner: System or Admins; full access: System, Admins; read/readandexecute/synchronize permissable: Authenticated Users
-    $privateKeyFiles = @("ssh_host_dsa_key", "ssh_host_ecdsa_key", "ssh_host_ed25519_key", "ssh_host_rsa_key")
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Exclude ($privateKeyFiles) -Force | ForEach-Object {
-        Repair-FilePermission -FilePath $_.FullName -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteAccessOK $authenticatedUserSid
-    } 
-    # Private key files - owner: System or Admins; full access: System, Admins
-    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include $privateKeyFiles -Force | ForEach-Object {
-        Repair-FilePermission -FilePath $_.FullName -Owners $adminsSid, $systemSid -FullAccessNeeded $systemSid, $adminsSid
-    }
+    Repair-FilePermission -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid,$systemSid -ReadAndExecuteAccessOK $authenticatedUserSid @psBoundParameters
+}
+
+<#
+    .Synopsis
+    Repair-SSHFilePermission
+    Repair the file owner and permission of files inside ProgramData\ssh folder
+#>
+function Repair-SSHFolderFilePermission
+{
+    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="High")]
+    param (
+        [parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]        
+        [string]$FilePath)
+
+
+    Repair-FilePermission -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteAccessOK $authenticatedUserSid @psBoundParameters
+}
+
+<#
+    .Synopsis
+    Repair-SSHFilePermission
+    Repair the file owner and permission of files inside ProgramData\ssh folder
+#>
+function Repair-SSHFolderPrivateKeyPermission
+{
+    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="High")]
+    param (
+        [parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]        
+        [string]$FilePath)
+
+
+    Repair-FilePermission -Owners $adminsSid, $systemSid -FullAccessNeeded $systemSid, $adminsSid @psBoundParameters
 }
 
 <#
@@ -808,4 +832,4 @@ function Enable-Privilege {
     $type[0]::EnablePrivilege($Privilege, $Disable)
 }
 
-Export-ModuleMember -Function Repair-FilePermission, Repair-SshdConfigPermission, Repair-SshdHostKeyPermission, Repair-AuthorizedKeyPermission, Repair-UserKeyPermission, Repair-UserSshConfigPermission, Enable-Privilege, Get-UserAccount, Get-UserSID, Repair-AdministratorsAuthorizedKeysPermission, Repair-ModuliFilePermission, Repair-SSHFolderPermission
+Export-ModuleMember -Function Repair-FilePermission, Repair-SshdConfigPermission, Repair-SshdHostKeyPermission, Repair-AuthorizedKeyPermission, Repair-UserKeyPermission, Repair-UserSshConfigPermission, Enable-Privilege, Get-UserAccount, Get-UserSID, Repair-AdministratorsAuthorizedKeysPermission, Repair-ModuliFilePermission, Repair-SSHFolderPermission, Repair-SSHFolderFilePermission, Repair-SSHFolderPrivateKeyPermission

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -273,7 +273,7 @@ function Repair-UserSshConfigPermission
 <#
     .Synopsis
     Repair-SSHFolderPermission
-    Repair the file owner and permission of ProgramData\ssh folder
+    Repair the folder owner and permission of ProgramData\ssh folder
 #>
 function Repair-SSHFolderPermission
 {
@@ -283,14 +283,13 @@ function Repair-SSHFolderPermission
         [ValidateNotNullOrEmpty()]        
         [string]$FilePath)
 
-    # SSH Folder - owner: System or Admins; full access: System, Admins; read or readandexecute/synchronize permissible: Authenticated Users
     Repair-FilePermission -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid,$systemSid -ReadAndExecuteAccessOK $authenticatedUserSid @psBoundParameters
 }
 
 <#
     .Synopsis
-    Repair-SSHFilePermission
-    Repair the file owner and permission of files inside ProgramData\ssh folder
+    Repair-SSHFolderFilePermission
+    Repair the file owner and permission of general files inside ProgramData\ssh folder
 #>
 function Repair-SSHFolderFilePermission
 {
@@ -300,14 +299,13 @@ function Repair-SSHFolderFilePermission
         [ValidateNotNullOrEmpty()]        
         [string]$FilePath)
 
-
     Repair-FilePermission -Owners $adminsSid, $systemSid -FullAccessNeeded $adminsSid, $systemSid -ReadAndExecuteAccessOK $authenticatedUserSid @psBoundParameters
 }
 
 <#
     .Synopsis
-    Repair-SSHFilePermission
-    Repair the file owner and permission of files inside ProgramData\ssh folder
+    Repair-SSHFolderPrivateKeyPermission
+    Repair the file owner and permission of private key files inside ProgramData\ssh folder
 #>
 function Repair-SSHFolderPrivateKeyPermission
 {
@@ -316,7 +314,6 @@ function Repair-SSHFolderPrivateKeyPermission
         [parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]        
         [string]$FilePath)
-
 
     Repair-FilePermission -Owners $adminsSid, $systemSid -FullAccessNeeded $systemSid, $adminsSid @psBoundParameters
 }

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -93,6 +93,7 @@ if (Test-Path $moduliPath -PathType Leaf)
 $sshProgDataPath = Join-Path $env:ProgramData "ssh"
 if (Test-Path $sshProgDataPath)
 {
+    # SSH Folder - owner: System or Admins; full access: System, Admins; read or readandexecute/synchronize permissible: Authenticated Users
     Repair-SSHFolderPermission -FilePath $sshProgDataPath @psBoundParameters
     # Files in SSH Folder (excluding private key files) 
     # owner: System or Admins; full access: System, Admins; read/readandexecute/synchronize permissable: Authenticated Users

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -4,6 +4,10 @@
 # @bingbing8 - removed secedit.exe dependency
 # @tessgauthier - added permissions check for %programData%/ssh
 
+[CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="High")]
+param ()
+Set-StrictMode -Version 2.0
+
 $ErrorActionPreference = 'Stop'
 
 if (!([bool]([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")))
@@ -82,14 +86,24 @@ if (Test-Path $sshAgentRegPath)
 $moduliPath = Join-Path $PSScriptRoot "moduli"
 if (Test-Path $moduliPath -PathType Leaf)
 {
-    Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters -confirm:$false
+    Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters
 }
 
 # If %programData%/ssh folder already exists, verify and, if necessary and approved by user, fix permissions 
 $sshProgDataPath = Join-Path $env:ProgramData "ssh"
 if (Test-Path $sshProgDataPath)
 {
-    Repair-SSHFolderPermission -sshProgDataPath $sshProgDataPath
+    Repair-SSHFolderPermission -FilePath $sshProgDataPath @psBoundParameters
+    # Files in SSH Folder (excluding private key files) 
+    # owner: System or Admins; full access: System, Admins; read/readandexecute/synchronize permissable: Authenticated Users
+    $privateKeyFiles = @("ssh_host_dsa_key", "ssh_host_ecdsa_key", "ssh_host_ed25519_key", "ssh_host_rsa_key")
+    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Exclude ($privateKeyFiles) -Force | ForEach-Object {
+        Repair-SSHFolderFilePermission -FilePath $_.FullName @psBoundParameters
+    }
+    # Private key files - owner: System or Admins; full access: System, Admins
+    Get-ChildItem -Path (Join-Path $sshProgDataPath '*') -Recurse -Include $privateKeyFiles -Force | ForEach-Object {
+        Repair-SSHFolderPrivateKeyPermission -FilePath $_.FullName @psBoundParameters
+    }
 }
 
 #register etw provider

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -86,7 +86,7 @@ if (Test-Path $sshAgentRegPath)
 $moduliPath = Join-Path $PSScriptRoot "moduli"
 if (Test-Path $moduliPath -PathType Leaf)
 {
-    Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters
+    Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters -confirm:$false
 }
 
 # If %programData%/ssh folder already exists, verify and, if necessary and approved by user, fix permissions 


### PR DESCRIPTION
- address PowerShell/Win32-OpenSSH#1916 
- splits Repair-SSHFolderPermission into 3 separate functions and moves some code from OpenSSHUtils.psm1 to install-sshd.ps1 so @psboundparameters can enable silent installation when `.\install-sshd.ps1` is called with `-Confirm:$false `