### PR TITLE
fix install-sshd incompatability with windows pwsh 5.1

### DIFF
--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -86,7 +86,7 @@ if (Test-Path $sshAgentRegPath)
 $moduliPath = Join-Path $PSScriptRoot "moduli"
 if (Test-Path $moduliPath -PathType Leaf)
 {
-    Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters -confirm:$false
+    Repair-ModuliFilePermission -FilePath $moduliPath -confirm:$false
 }
 
 # If %programData%/ssh folder already exists, verify and, if necessary and approved by user, fix permissions 

--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -86,7 +86,13 @@ if (Test-Path $sshAgentRegPath)
 $moduliPath = Join-Path $PSScriptRoot "moduli"
 if (Test-Path $moduliPath -PathType Leaf)
 {
-    Repair-ModuliFilePermission -FilePath $moduliPath -confirm:$false
+    # if user calls .\install-sshd.ps1 with -confirm, use that
+    # otherwise, need to preserve legacy behavior
+    if (-not $PSBoundParameters.ContainsKey('confirm'))
+    {
+        $PSBoundParameters.add('confirm', $false)
+    }
+    Repair-ModuliFilePermission -FilePath $moduliPath @psBoundParameters
 }
 
 # If %programData%/ssh folder already exists, verify and, if necessary and approved by user, fix permissions 


### PR DESCRIPTION
- address [#1916](https://github.com/PowerShell/Win32-OpenSSH/issues/1916)
- modifies logic of the `-confirm` parameter passed into ` Repair-ModuliFilePermission` by using the input value of `.\install-sshd.ps1 -confirm:($true/$false)`, if it is provided, and, if not, sets the legacy value of `-confirm:$false`
- tested on Windows PowerShell 5.1 & PowerShell 7.2