### PR TITLE
Fix duplicate symbols from posix_compat, openbsd_compat with libcrypto

### DIFF
--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -206,13 +206,13 @@
 /* #undef HAVE_ADDR_V6_IN_UTMPX */
 
 /* Define to 1 if you have the `arc4random' function. */
-/* #undef HAVE_ARC4RANDOM */
+#define HAVE_ARC4RANDOM 1
 
 /* Define to 1 if you have the `arc4random_buf' function. */
-/* #undef HAVE_ARC4RANDOM_BUF */
+#define HAVE_ARC4RANDOM_BUF 1
 
 /* Define to 1 if you have the `arc4random_uniform' function. */
-/* #undef HAVE_ARC4RANDOM_UNIFORM */
+#define HAVE_ARC4RANDOM_UNIFORM 1
 
 /* Define to 1 if you have the `asprintf' function. */
 /* #undef HAVE_ASPRINTF */

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -190,7 +190,7 @@ nanosleep(const struct timespec *req, struct timespec *rem)
  * Copyright (c) 2009, 2010 NoMachine
  * All rights reserved
  */
-int
+static int
 gettimeofday(struct timeval *tv, void *tz)
 {
 	union {
@@ -212,7 +212,7 @@ gettimeofday(struct timeval *tv, void *tz)
 	return 0;
 }
 
-void
+static void
 explicit_bzero(void *b, size_t len)
 {
 	SecureZeroMemory(b, len);
@@ -1480,7 +1480,7 @@ localtime_r(const time_t *timep, struct tm *result)
 	return localtime_s(result, timep) == 0 ? result : NULL;
 }
 
-void
+static void
 freezero(void *ptr, size_t sz)
 {
 	if (ptr == NULL)


### PR DESCRIPTION
I am currently working on a complete CMake build system for Win32 OpenSSH, and I noticed that the current Visual Studio project files rely on `<ForceFileOutput>MultiplyDefinedSymbolOnly</ForceFileOutput>` or /FORCE:MULTIPLE to build "properly" due to conflicting symbols:

- posix_compat defines explicit_bzero, freezero, gettimeofday duplicate symbols with libcrypto
- openbsd_compat defines arc4random, arc4random_buf, arc4random_uniform duplicate symbols with libcrypto

Forcing the link to ignore duplicate symbols means we don't really know which one gets picked in the end. Assuming that we wish to use the symbols defined in libcrypto, I resolved the posix_compat conflict by making all three function static, and I resolved the openbsd_compat conflict by defining HAVE_ARC4RANDOM, HAVE_ARC4RANDOM_BUF, HAVE_ARC4RANDOM_UNIFORM in config.h.vs.

With both conflicts resolved, I could get Win32 OpenSSH built without having to force MSVC to YOLO-link the duplicate symbols.