### PR TITLE
Minor non-Windows build portability fixes

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -83,6 +83,7 @@
 #include "canohost.h"
 #include "log.h"
 #include "misc.h"
+#include "msg.h"
 #include "servconf.h"
 #include "monitor.h"
 #ifdef GSSAPI

--- a/ssh-pkcs11-client.c
+++ b/ssh-pkcs11-client.c
@@ -509,10 +509,12 @@ pkcs11_start_helper(void)
 #endif
 	/* success */
 	debug3_f("started pid=%ld", (long)pid);
+#ifdef WINDOWS
 out:
 	if (client_token)
 		CloseHandle(client_token);
 	return r;
+#endif
 }
 
 int


### PR DESCRIPTION
Despite the fact that Win32-OpenSSH is meant for Windows, I've got it to build on Linux with minimal fixes. This is important to me because I've working on a cross-platform OpenSSH downstream fork that incorporates the Win32-OpenSSH changes, and having a single set of patches that builds everywhere is definitely a lot easier to maintain.

- fix ssh-pkcs11-client.c missing ifdef
- fix missing msg.h include in monitor.c
