### PR TITLE
fix debug exception with static method

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1480,7 +1480,7 @@ localtime_r(const time_t *timep, struct tm *result)
 	return localtime_s(result, timep) == 0 ? result : NULL;
 }
 
-static void
+void
 freezero(void *ptr, size_t sz)
 {
 	if (ptr == NULL)


### PR DESCRIPTION
- fix exception thrown during sshd startup for binaries compiled with debug configuration, specifically with /MTd, (rather than /MT for release configuration)