### PR TITLE
Fix not to assign null to strstr function

### DIFF
--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -469,7 +469,7 @@ int do_exec_windows(struct ssh *ssh, Session *s, const char *command, int pty) {
 		}
 		
 		//Passing the PRIVSEP_LOG_FD (STDERR_FILENO + 2) to sftp-server for logging
-		if (command) {
+		if (exec_command) {
 			if (strstr(exec_command, "sftp-server.exe")) {
 				if (posix_spawn_file_actions_adddup2(&actions, STDERR_FILENO + 2, SFTP_SERVER_LOG_FD) != 0) {
 					errno = EOTHER;

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -469,12 +469,15 @@ int do_exec_windows(struct ssh *ssh, Session *s, const char *command, int pty) {
 		}
 		
 		//Passing the PRIVSEP_LOG_FD (STDERR_FILENO + 2) to sftp-server for logging
-		if(strstr(exec_command, "sftp-server.exe"))
-			if (posix_spawn_file_actions_adddup2(&actions, STDERR_FILENO + 2, SFTP_SERVER_LOG_FD) != 0) {
-				errno = EOTHER;
-				error("posix_spawn initialization failed");
-				goto cleanup;
+		if (command) {
+			if (strstr(exec_command, "sftp-server.exe")) {
+				if (posix_spawn_file_actions_adddup2(&actions, STDERR_FILENO + 2, SFTP_SERVER_LOG_FD) != 0) {
+					errno = EOTHER;
+					error("posix_spawn initialization failed");
+					goto cleanup;
+				}
 			}
+		}
 
 		if (posix_spawn(&pid, spawn_argv[0], &actions, NULL, spawn_argv, NULL) != 0) {
 			errno = EOTHER;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixed a bug that caused the sshd process to crash when executing "ssh -T _hostname_".

<!-- Summarize your PR between here and the checklist. -->

## PR Context
I found the sshd process crashing when trying to ssh login from a client machine using "ssh -T _hostname_".
This is because null is read into the strstr() function below.

```
		//Passing the PRIVSEP_LOG_FD (STDERR_FILENO + 2) to sftp-server for logging
		if(strstr(exec_command, "sftp-server.exe"))
			if (posix_spawn_file_actions_adddup2(&actions, STDERR_FILENO + 2, SFTP_SERVER_LOG_FD) != 0) {
				errno = EOTHER;
				error("posix_spawn initialization failed");
				goto cleanup;
			}
```
I modified the program to call the strstr() function when it's not null.
This fix allows us ssh login with "ssh -T _hostname_".

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
