### PR TITLE
update duplicateargs to copy args properly

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -1149,7 +1149,7 @@ duplicateargs(arglist *dest, arglist *source)
 	
 	if (source->list != NULL) {
 		for (int i = 0; i < source->num; i++) {
-			addargs(dest, source->list[i]);
+			addargs(dest, "%s", source->list[i]);
 		}
 	}
 }

--- a/regress/scp.sh
+++ b/regress/scp.sh
@@ -110,7 +110,7 @@ for mode in scp sftp ; do
 		scpclean
 		cp ${DATA} ${COPY}
 		$SCP "${scpopts[@]}" -vvv -o '"%h %p"' ${COPY} somehost:${DIR} 2>&1 | tee scp_printf_test.txt
-		# relies on logs from debug3: spawning statement 
+		# relies on debug log statement, specifically from "debug3: spawning..." 
 		[[ " $( cat "scp_printf_test.txt" ) " =~ "%h %p" ]] || fail "input args & printf check failed"
 		rm -f scp_printf_test.txt
 	fi

--- a/regress/scp.sh
+++ b/regress/scp.sh
@@ -105,6 +105,16 @@ for mode in scp sftp ; do
 	 $SCP "${scpopts[@]}" *metachar* ${DIR2} 2>&1 2>/dev/null; \
 	 [ ! -f metachartest ] ) || fail "shell metacharacters"
 
+	if test $mode = scp ; then
+		verbose "$tag: input args & printf check"
+		scpclean
+		cp ${DATA} ${COPY}
+		$SCP "${scpopts[@]}" -vvv -o '"%h %p"' ${COPY} somehost:${DIR} 2>&1 | tee scp_printf_test.txt
+		# relies on logs from debug3: spawning statement 
+		[[ " $( cat "scp_printf_test.txt" ) " =~ "%h %p" ]] || fail "input args & printf check failed"
+		rm -f scp_printf_test.txt
+	fi
+
 	if [ ! -z "$SUDO" ]; then
 		verbose "$tag: skipped file after scp -p with failed chown+utimes"
 		scpclean


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

 address https://github.com/PowerShell/Win32-OpenSSH/issues/1972

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

OpenSSH 8.9 introduced a method to duplicate scp args before spawning a new process, utilizing an existing addargs method. To copy the existing strings, the addargs method needs to receive the destination string, format string, and source string as arguments. Previously, it was only receiving the destination string and source string, leading to formatting issues with special identifiers like %h and %p.