### PR TITLE
Fix restrict_websafe option in ssh-agent

### DIFF
--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -808,7 +808,8 @@ process_sign_request2(SocketEntry *e)
 		goto send;
 	}
 	if (sshkey_is_sk(id->key)) {
-		if (strncmp(id->key->sk_application, "ssh:", 4) != 0 &&
+		if (restrict_websafe &&
+		    strncmp(id->key->sk_application, "ssh:", 4) != 0 &&
 		    !check_websafe_message_contents(key, data)) {
 			/* error already logged */
 			goto send;


### PR DESCRIPTION
# PR Summary

Backport of an upstream patch to ssh-agent to make it possible to disable the "restrict_websafe" option.

## PR Context

By default, ssh-agent restricts signing requests to security keys in order to ensure that remote sites can't attempt to use non-SSH keys. However, disabling this restriction allows proxying of arbitrary WebAuthN requests to these keys, making it possible to ssh into a remote machine and satisfy WebAuthN requests there using a local key. ssh-agent has an option that was intended to disable this restriction, but the variable it set was never checked and this was always enforced. Upstream has now fixed this, but it would be helpful to have it backported.