### PR TITLE
Complete pending write operations before canceling io.

### DIFF
--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -261,7 +261,14 @@ syncio_close(struct w32_io* pio)
 {
 	debug4("syncio_close - pio:%p", pio);
 
-	/* Flush descriptor.*/
+	/*
+	* Wait for io write operation that is called by worker thread to terminate
+	* to avoid the write operation being terminated prematurely by CancelIoEx.
+	* If you see any process waiting here indefinitely - its because no one
+	* is draining from other end of the pipe. This is an unfortunate
+	* consequence that should otherwise have very little impact on practical
+	* scenarios.
+	*/
 	if (pio->write_details.pending) {
 		WaitForSingleObject(pio->write_overlapped.hEvent, INFINITE);
 

--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -269,9 +269,6 @@ syncio_close(struct w32_io* pio)
 		SleepEx(0, TRUE);
 	}
 
-	// This call is likely racy, there's no guarantee
-	// that a thread has begun IO operations when it's called.
-	// Why stop io operations when we're going to close it anyhow?
 	CancelIoEx(WINHANDLE(pio), NULL);
 
 	/* If io is pending, let worker threads exit. */


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Resolve Early Cancellation of pipelines.
https://github.com/PowerShell/Win32-OpenSSH/issues/2012

<!-- Summarize your PR between here and the checklist. -->

## PR Context
As described in PowerShell/Win32-OpenSSH#2012 when a process such as git uses ssh as a channel, WinSSH will prematurely terminate before flushing all data to the pipe. This results in the error `Early EOF`.

To fix this issue, when closing the pipe, we first complete write operations to it before cancelling IO on it, rather than afterwards (tbh the current logic makes no sense). That said, I believe a simpler way of addressing the issue is simply to remove the IO cancel completely, though this may make the process slightly less responsive to Ctrl-C.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
