### PR TITLE
[WIP] Stop setting SO_REUSEADDR to fix Port Forwarding 

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -3683,8 +3683,18 @@ channel_setup_fwd_listener_tcpip(struct ssh *ssh, int type,
 			    strerror(errno));
 			continue;
 		}
-
+#ifndef WINDOWS
+		/*
+		Setting the SO_REUSEADDR flag on a socket behaves differently on Windows than on *NIX OS.
+		On *NIX OS, the flag is used for  handling specific edge cases and allows the tag to be reused
+		while busy only during TIME_WAIT state in the short period after termination.
+		On Windows, the option allows a socket to forcibly bind to a port in use by another socket in any
+		state.
+		This was allowing more than one socket to be created in the same port on Windows, which is 
+		unnexpected behavior.
+		*/
 		set_reuseaddr(sock);
+#endif
 		if (ai->ai_family == AF_INET6)
 			sock_set_v6only(sock);
 

--- a/channels.c
+++ b/channels.c
@@ -3686,7 +3686,7 @@ channel_setup_fwd_listener_tcpip(struct ssh *ssh, int type,
 #ifndef WINDOWS
 		/*
 		Setting the SO_REUSEADDR flag on a socket behaves differently on Windows than on *NIX OS.
-		On *NIX OS, the flag is used for  handling specific edge cases and allows the tag to be reused
+		On *NIX OS, the flag is used for  handling specific edge cases and allows the port to be reused
 		while busy only during TIME_WAIT state in the short period after termination.
 		On Windows, the option allows a socket to forcibly bind to a port in use by another socket in any
 		state.

--- a/sshd.c
+++ b/sshd.c
@@ -1472,7 +1472,9 @@ listen_on_addrs(struct listenaddr *la)
 			continue;
 		}
 		/* Socket options */
+#ifndef WINDOWS
 		set_reuseaddr(listen_sock);
+#endif
 		if (la->rdomain != NULL &&
 		    set_rdomain(listen_sock, la->rdomain) == -1) {
 			close(listen_sock);


### PR DESCRIPTION
Fix: https://github.com/PowerShell/Win32-OpenSSH/issues/1968

# PR Summary

SO_REUSEADDR socket option means different things on Windows and *nix systems.
On Windows, that option allows sockets to forcibly bind to ports in use by other sockets. The behavior for all sockets once the second socket is bound to the port is indeterminate. (See: https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#using-so_reuseaddr)

On *nix systems, the SO_REUSEADDR is used to address edge cases that might occur after socket termination. It allows the socket to be reused while it is on TIME_WAIT state. It still returns "Address already in use" error if the socket is being used while in any other state. (See: https://stackoverflow.com/questions/3229860/what-is-the-meaning-of-so-reuseaddr-setsockopt-option-linux)

Supposedly, Windows doesn't have the issue of preventing the reutilization of sockets during TIME_WAIT (according to this discussion: https://github.com/warmcat/libwebsockets/issues/65#issuecomment-74990312), so there should be no value for us to use the SO_REUSEADDR when creating sockets.
