### PR TITLE
revert adding motw for sftp uploads

### DIFF
--- a/sftp-server.c
+++ b/sftp-server.c
@@ -882,19 +882,6 @@ process_write(u_int32_t id)
 	    (r = sshbuf_get_string(iqueue, &data, &len)) != 0)
 		fatal_fr(r, "parse");
 
-#ifdef WINDOWS
-	char* filepath = resolved_path_utf8(handle_to_name(handle));
-	if (filepath == NULL) {
-		debug("cannot convert handle %d to utf8 filepath for mark of the web", handle);
-	}
-	else {
-		if (add_mark_of_web(filepath) == -1) {
-			debug("add_mark_of_web to %s failed", filepath);
-		}
-		free(filepath);
-	}
-#endif // WINDOWS
-
 	debug("request %u: write \"%s\" (handle %d) off %llu len %zu",
 	    id, handle_to_name(handle), handle, (unsigned long long)off, len);
 	fd = handle_to_fd(handle);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Revert Mark-of-the-Web (MOTW) changes in sftp-server.c, as MOTW is not intended for file uploads. This behavior is also consistent with scp's file upload behavior. 
 
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Address https://github.com/PowerShell/Win32-OpenSSH/issues/2029
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
