### PR TITLE
It is a workaround to address the #2027 issue.

### DIFF
--- a/contrib/win32/win32compat/win32-utf8.c
+++ b/contrib/win32/win32compat/win32-utf8.c
@@ -11,7 +11,7 @@
 UINT g_previous_codepage = 0;
 
 void
-mresetlocale(void);
+mrestorelocale(void);
 
 int
 vfmprintf(FILE *stream, const char *fmt, va_list ap)
@@ -100,19 +100,22 @@ asmprintf(char **outp, size_t sz, int *written, const char *fmt, ...)
 void
 msetlocale(void)
 {
-	// allow console output of unicode characters
-	g_previous_codepage = SetConsoleOutputCP(CP_UTF8);
+	// save previous codepage
+	g_previous_codepage = GetConsoleOutputCP();
 
-	// register reset function at exit
-	atexit(mresetlocale);
+	// allow console output of unicode characters
+	SetConsoleOutputCP(CP_UTF8);
+
+	// register a restore function at exit
+	atexit(mrestorelocale);
 }
 
 void
-mresetlocale(void)
+mrestorelocale(void)
 {
 	if( 0 != g_previous_codepage )
 	{
-		// restore console output codepage for previous one
+		// restore console output codepage to previous one
 		SetConsoleOutputCP(g_previous_codepage);
 	}
 }

--- a/contrib/win32/win32compat/win32-utf8.c
+++ b/contrib/win32/win32compat/win32-utf8.c
@@ -7,6 +7,11 @@
 
 #include "console.h"
 
+// previous codepage
+UINT g_previous_codepage = 0;
+
+void
+mresetlocale(void);
 
 int
 vfmprintf(FILE *stream, const char *fmt, va_list ap)
@@ -96,6 +101,18 @@ void
 msetlocale(void)
 {
 	// allow console output of unicode characters
-	SetConsoleOutputCP(CP_UTF8);
+	g_previous_codepage = SetConsoleOutputCP(CP_UTF8);
+
+	// register reset function at exit
+	atexit(mresetlocale);
 }
 
+void
+mresetlocale(void)
+{
+	if( 0 != g_previous_codepage )
+	{
+		// restore console output codepage for previous one
+		SetConsoleOutputCP(g_previous_codepage);
+	}
+}


### PR DESCRIPTION
I implemented a workaround for the #2027 issue.

# PR Summary

- Implemented the mresetconsole function.
- added call to atexit function so that mresetconsole function is called before program termination when msetconsole is called

## PR Context

I wrote a workaround to address the #2027 issue.