### PR TITLE
change server firewall settings to private profile only

### DIFF
--- a/contrib/win32/install/server.wxs
+++ b/contrib/win32/install/server.wxs
@@ -49,6 +49,7 @@
                     Protocol="tcp"
                     Port="22"
                     Scope="any"
+                    Profile="private"
                     />
             </Component>
             <Component>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
During installation of SSH server via MSI, the firewall rule will be applied for private profile only, instead of the default value of all. 
<!-- Summarize your PR between here and the checklist. -->

## PR Context
https://wixtoolset.org/docs/reference/schema/firewall/firewallexception/
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
