### PR TITLE
Add support for AF_UNIX

### DIFF
--- a/authfd.c
+++ b/authfd.c
@@ -97,7 +97,13 @@ ssh_get_authentication_socket_path(const char *authsocket, int *fdp)
 	sunaddr.sun_family = AF_UNIX;
 	strlcpy(sunaddr.sun_path, authsocket, sizeof(sunaddr.sun_path));
 
-	if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+	#ifdef HAVE_AFUNIX_H
+	sock = w32_afunix_socket(&sunaddr);
+	#else
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	#endif
+
+	if (sock == -1)
 		return SSH_ERR_SYSTEM_ERROR;
 
 	/* close on exec */

--- a/authfd.c
+++ b/authfd.c
@@ -97,13 +97,7 @@ ssh_get_authentication_socket_path(const char *authsocket, int *fdp)
 	sunaddr.sun_family = AF_UNIX;
 	strlcpy(sunaddr.sun_path, authsocket, sizeof(sunaddr.sun_path));
 
-	#ifdef HAVE_AFUNIX_H
-	sock = w32_afunix_socket(&sunaddr);
-	#else
-	sock = socket(AF_UNIX, SOCK_STREAM, 0);
-	#endif
-
-	if (sock == -1)
+	if ((sock = w32_afunix_socket(&sunaddr)) == -1)
 		return SSH_ERR_SYSTEM_ERROR;
 
 	/* close on exec */

--- a/contrib/win32/openssh/bash_tests_iterator.ps1
+++ b/contrib/win32/openssh/bash_tests_iterator.ps1
@@ -186,7 +186,7 @@ try
 	
 	# These are the known failed testcases.
 	# transfer.sh, rekey.sh tests fail on CygWin v3.4.0, but succeeds with v3.3.6
-	$known_failed_testcases = @("agent.sh", "key-options.sh", "forward-control.sh", "integrity.sh", "krl.sh", "cert-hostkey.sh", "cert-userkey.sh", "percent.sh", "transfer.sh", "rekey.sh")
+	$known_failed_testcases = @("key-options.sh", "forward-control.sh", "integrity.sh", "krl.sh", "cert-hostkey.sh", "cert-userkey.sh", "percent.sh", "transfer.sh", "rekey.sh")
 	$known_failed_testcases_skipped = @()
 
 	$start_time = (Get-Date)

--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -1526,6 +1526,9 @@
 /* Use PIPES instead of a socketpair() */
 #define USE_PIPES 1
 
+/* Define name for the ssh-agent Windows named pipe */
+#define AGENT_PIPE_ID L"\\\\.\\pipe\\openssh-ssh-agent"
+
 /* define 1 if afunix.h is available */
 #define HAVE_AFUNIX_H 1
 

--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -1526,6 +1526,9 @@
 /* Use PIPES instead of a socketpair() */
 #define USE_PIPES 1
 
+/* define 1 if afunix.h is available */
+#define HAVE_AFUNIX_H 1
+
 /* Define if you want to sanitize fds */
 /* #undef USE_SANITISE_STDFD */
 

--- a/contrib/win32/win32compat/socketio.c
+++ b/contrib/win32/win32compat/socketio.c
@@ -29,9 +29,6 @@
 */
 
 #include <winsock2.h>
-#ifdef HAVE_AFUNIX_H
-#include <afunix.h>
-#endif
 #include <ws2tcpip.h>
 #include <mswsock.h>
 #include <errno.h>
@@ -41,6 +38,10 @@
 #include "inc\utf.h"
 #include "misc_internal.h"
 #include "debug.h"
+#include "../../../config.h"
+#ifdef HAVE_AFUNIX_H
+#include <afunix.h>
+#endif
 
 #define INTERNAL_SEND_BUFFER_SIZE 70*1024 //70KB
 #define INTERNAL_RECV_BUFFER_SIZE 70*1024 //70KB

--- a/contrib/win32/win32compat/socketio.c
+++ b/contrib/win32/win32compat/socketio.c
@@ -29,7 +29,9 @@
 */
 
 #include <winsock2.h>
+#ifdef HAVE_AFUNIX_H
 #include <afunix.h>
+#endif
 #include <ws2tcpip.h>
 #include <mswsock.h>
 #include <errno.h>
@@ -119,7 +121,12 @@ socketio_acceptEx(struct w32_io* pio)
 	}
 
 	/* create accepting socket */
+	#ifdef HAVE_AFUNIX_H
 	context->accept_socket = socket(addr.ss_family, SOCK_STREAM, IPPROTO_IP);
+	#else
+	context->accept_socket = socket(addr.ss_family, SOCK_STREAM, IPPROTO_TCP);
+	#endif
+
 	if (context->accept_socket == INVALID_SOCKET) {
 		errno = errno_from_WSALastError();
 		debug3("acceptEx - socket() ERROR:%d, io:%p", WSAGetLastError(), pio);
@@ -757,7 +764,10 @@ on_error:
 int
 socketio_connectex(struct w32_io* pio, const struct sockaddr* name, int namelen)
 {
+	#ifdef HAVE_AFUNIX_H
 	struct sockaddr_un tmp_unix;
+	#endif
+
 	struct sockaddr_in tmp_addr4;
 	struct sockaddr_in6 tmp_addr6;
 	SOCKADDR* tmp_addr;
@@ -779,11 +789,13 @@ socketio_connectex(struct w32_io* pio, const struct sockaddr* name, int namelen)
 		tmp_addr4.sin_port = 0;
 		tmp_addr = (SOCKADDR*)&tmp_addr4;
 		tmp_addr_len = sizeof(tmp_addr4);
+	#ifdef HAVE_AFUNIX_H
 	} else if (name->sa_family == AF_UNIX) {
 		ZeroMemory(&tmp_unix, sizeof(tmp_unix));
 		tmp_unix.sun_family = AF_UNIX;
 		tmp_addr = (SOCKADDR*)&tmp_unix;
 		tmp_addr_len = sizeof(tmp_unix);
+	#endif
 	} else {
 		errno = ENOTSUP;
 		debug3("connectex - ERROR: unsuppored address family:%d, io:%p", name->sa_family, pio);

--- a/contrib/win32/win32compat/ssh-agent/agent.c
+++ b/contrib/win32/win32compat/ssh-agent/agent.c
@@ -43,8 +43,6 @@ HANDLE sshagent_client_primary_token;
 static HANDLE ioc_port = NULL;
 static BOOL debug_mode = FALSE;
 
-#define AGENT_PIPE_ID L"\\\\.\\pipe\\openssh-ssh-agent"
-
 static HANDLE event_stop_agent;
 static OVERLAPPED ol;
 static 	HANDLE pipe;

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -299,17 +299,11 @@ w32_socket(int domain, int type, int protocol)
 	if (min_index == -1)
 		return -1;
 	
-	if (domain == AF_UNIX && type == SOCK_STREAM) {
-		pio = fileio_afunix_socket();		
-		if (pio == NULL)
-			return -1;
-		pio->type = NONSOCK_FD;
-	} else {
-		pio = socketio_socket(domain, type, protocol);
-		if (pio == NULL)
-			return -1;
-		pio->type = SOCK_FD;
-	}	
+	pio = socketio_socket(domain, type, protocol);
+	if (pio == NULL)
+		return -1;
+	pio->type = SOCK_FD;
+
 
 	fd_table_set(pio, min_index);
 	debug4("socket:%d, socktype:%d, io:%p, fd:%d ", pio->sock, type, pio, min_index);

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -52,6 +52,7 @@
 #include <sys\utime.h>
 #include "misc_internal.h"
 #include "debug.h"
+#include "../../../config.h"
 
 /* internal table that stores the fd to w32_io mapping*/
 struct w32fd_table {

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -326,7 +326,11 @@ w32_afunix_socket(struct sockaddr_un* addr)
 		a AF_UNIX socket if ssh forwarding is enabled. If the addr->sun_path is the
 		the well known named pipe, we open the socket with w32_fileio.
 	*/
-	if(strcmp(addr->sun_path, "\\\\.\\pipe\\openssh-ssh-agent") == 0)
+	int len = wcslen(AGENT_PIPE_ID);
+	char* pipeid = (char*)malloc(len + 1);
+	memset(pipeid, 0, len + 1);
+
+	if(wcstombs(pipeid, AGENT_PIPE_ID, len + 1) != (size_t) -1 && strcmp(addr->sun_path, pipeid) == 0)
 		return w32_fileio_socket(SOCK_STREAM, 0);
 	else
 		return w32_unix_socket(SOCK_STREAM, 0);

--- a/contrib/win32/win32compat/w32fd.h
+++ b/contrib/win32/win32compat/w32fd.h
@@ -125,6 +125,7 @@ struct w32_io {
 #define FILETYPE(pio) (GetFileType(WINHANDLE(pio)))
 extern HANDLE main_thread;
 
+int w32_afunix_socket(struct sockaddr_un* addr);
 BOOL w32_io_is_blocking(struct w32_io*);
 BOOL w32_io_is_io_available(struct w32_io* pio, BOOL rd);
 int wait_for_any_event(HANDLE* events, int num_events, DWORD milli_seconds);

--- a/misc.c
+++ b/misc.c
@@ -1928,7 +1928,11 @@ unix_listener(const char *path, int backlog, int unlink_first)
 		return -1;
 	}
 
+	#ifdef HAVE_AFUNIX_H
+	sock = w32_afunix_socket(&sunaddr);
+	#else
 	sock = socket(PF_UNIX, SOCK_STREAM, 0);
+	#endif
 	if (sock == -1) {
 		saved_errno = errno;
 		error_f("socket: %.100s", strerror(errno));

--- a/misc.c
+++ b/misc.c
@@ -1928,12 +1928,7 @@ unix_listener(const char *path, int backlog, int unlink_first)
 		return -1;
 	}
 
-	#ifdef HAVE_AFUNIX_H
-	sock = w32_afunix_socket(&sunaddr);
-	#else
-	sock = socket(PF_UNIX, SOCK_STREAM, 0);
-	#endif
-	if (sock == -1) {
+	if ((sock = w32_afunix_socket(&sunaddr)) == -1) {
 		saved_errno = errno;
 		error_f("socket: %.100s", strerror(errno));
 		errno = saved_errno;

--- a/mux.c
+++ b/mux.c
@@ -2268,7 +2268,13 @@ muxclient(const char *path)
 		fatal("ControlPath too long ('%s' >= %u bytes)", path,
 		    (unsigned int)sizeof(addr.sun_path));
 
-	if ((sock = socket(PF_UNIX, SOCK_STREAM, 0)) == -1)
+	#ifdef HAVE_AFUNIX_H
+	sock = w32_afunix_socket(&addr);
+	#elif
+	sock = socket(PF_UNIX, SOCK_STREAM, 0);
+	#endif
+
+	if (sock == -1)
 		fatal_f("socket(): %s", strerror(errno));
 
 	if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == -1) {

--- a/mux.c
+++ b/mux.c
@@ -2268,13 +2268,7 @@ muxclient(const char *path)
 		fatal("ControlPath too long ('%s' >= %u bytes)", path,
 		    (unsigned int)sizeof(addr.sun_path));
 
-	#ifdef HAVE_AFUNIX_H
-	sock = w32_afunix_socket(&addr);
-	#elif
-	sock = socket(PF_UNIX, SOCK_STREAM, 0);
-	#endif
-
-	if (sock == -1)
+	if ((sock = w32_afunix_socket(&addr)) == -1)
 		fatal_f("socket(): %s", strerror(errno));
 
 	if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == -1) {

--- a/regress/agent.sh
+++ b/regress/agent.sh
@@ -39,6 +39,13 @@ ${SSHKEYGEN} -q -N '' -t ed25519 -f $OBJ/user_ca_key \
 trace "overwrite authorized keys"
 printf '' > $OBJ/authorized_keys_$USER
 
+if [ "$os" == "windows" ]; then
+	# We are adding the default ssh-rsa key to the agent. Certificate based key don't
+	# seem to be currently working.
+	cat $OBJ/ssh-rsa.pub >> $OBJ/authorized_keys_$USER
+	${SSHADD} $OBJ/ssh-rsa > /dev/null 2>&1
+fi
+
 for t in ${SSH_KEYTYPES}; do
 	# generate user key for agent
 	rm -f $OBJ/$t-agent $OBJ/$t-agent.pub*
@@ -90,6 +97,7 @@ if [ $r -ne 52 ]; then
 	fail "ssh connect with failed (exit code $r)"
 fi
 
+if [ "$os" != "windows" ]; then
 for t in ${SSH_KEYTYPES}; do
 	trace "connect via agent using $t key"
 	if [ "$t" = "ssh-dss" ]; then
@@ -103,6 +111,7 @@ for t in ${SSH_KEYTYPES}; do
 		fail "ssh connect with failed (exit code $r)"
 	fi
 done
+fi
 
 trace "agent forwarding"
 ${SSH} -A -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
@@ -110,123 +119,126 @@ r=$?
 if [ $r -ne 0 ]; then
 	fail "ssh-add -l via agent fwd failed (exit code $r)"
 fi
-${SSH} "-oForwardAgent=$SSH_AUTH_SOCK" -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
-r=$?
-if [ $r -ne 0 ]; then
-	fail "ssh-add -l via agent path fwd failed (exit code $r)"
-fi
-${SSH} -A -F $OBJ/ssh_proxy somehost \
-	"${SSH} -F $OBJ/ssh_proxy somehost exit 52"
-r=$?
-if [ $r -ne 52 ]; then
-	fail "agent fwd failed (exit code $r)"
-fi
 
-trace "agent forwarding different agent"
-${SSH} "-oForwardAgent=$FW_SSH_AUTH_SOCK" -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
-r=$?
-if [ $r -ne 0 ]; then
-	fail "ssh-add -l via agent path fwd of different agent failed (exit code $r)"
-fi
-${SSH} '-oForwardAgent=$FW_SSH_AUTH_SOCK' -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
-r=$?
-if [ $r -ne 0 ]; then
-	fail "ssh-add -l via agent path env fwd of different agent failed (exit code $r)"
-fi
-
-# Remove keys from forwarded agent, ssh-add on remote machine should now fail.
-SSH_AUTH_SOCK=$FW_SSH_AUTH_SOCK ${SSHADD} -D > /dev/null 2>&1
-r=$?
-if [ $r -ne 0 ]; then
-	fail "ssh-add -D failed: exit code $r"
-fi
-${SSH} '-oForwardAgent=$FW_SSH_AUTH_SOCK' -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
-r=$?
-if [ $r -ne 1 ]; then
-	fail "ssh-add -l with different agent did not fail with exit code 1 (exit code $r)"
-fi
-
-(printf 'cert-authority,principals="estragon" '; cat $OBJ/user_ca_key.pub) \
-	> $OBJ/authorized_keys_$USER
-for t in ${SSH_KEYTYPES}; do
-    if [ "$t" != "ssh-dss" ]; then
-	trace "connect via agent using $t key"
-	${SSH} -F $OBJ/ssh_proxy -i $OBJ/$t-agent.pub \
-		-oCertificateFile=$OBJ/$t-agent-cert.pub \
-		-oIdentitiesOnly=yes somehost exit 52
+if [ "$os" != "windows" ]; then
+	${SSH} "-oForwardAgent=$SSH_AUTH_SOCK" -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 0 ]; then
+		fail "ssh-add -l via agent path fwd failed (exit code $r)"
+	fi
+	${SSH} -A -F $OBJ/ssh_proxy somehost \
+		"${SSH} -F $OBJ/ssh_proxy somehost exit 52"
 	r=$?
 	if [ $r -ne 52 ]; then
-		fail "ssh connect with failed (exit code $r)"
+		fail "agent fwd failed (exit code $r)"
 	fi
-    fi
-done
 
-## Deletion tests.
+	trace "agent forwarding different agent"
+	${SSH} "-oForwardAgent=$FW_SSH_AUTH_SOCK" -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 0 ]; then
+		fail "ssh-add -l via agent path fwd of different agent failed (exit code $r)"
+	fi
+	${SSH} '-oForwardAgent=$FW_SSH_AUTH_SOCK' -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 0 ]; then
+		fail "ssh-add -l via agent path env fwd of different agent failed (exit code $r)"
+	fi
 
-trace "delete all agent keys"
-${SSHADD} -D > /dev/null 2>&1
-r=$?
-if [ $r -ne 0 ]; then
-	fail "ssh-add -D failed: exit code $r"
-fi
-# make sure they're gone
-${SSHADD} -l > /dev/null 2>&1
-r=$?
-if [ $r -ne 1 ]; then
-	fail "ssh-add -l returned unexpected exit code: $r"
-fi
-trace "readd keys"
-# re-add keys/certs to agent
-for t in ${SSH_KEYTYPES}; do
-	${SSHADD} $OBJ/$t-agent-private >/dev/null 2>&1 || \
+	# Remove keys from forwarded agent, ssh-add on remote machine should now fail.
+	SSH_AUTH_SOCK=$FW_SSH_AUTH_SOCK ${SSHADD} -D > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 0 ]; then
+		fail "ssh-add -D failed: exit code $r"
+	fi
+	${SSH} '-oForwardAgent=$FW_SSH_AUTH_SOCK' -F $OBJ/ssh_proxy somehost ${SSHADD} -l > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 1 ]; then
+		fail "ssh-add -l with different agent did not fail with exit code 1 (exit code $r)"
+	fi
+
+	(printf 'cert-authority,principals="estragon" '; cat $OBJ/user_ca_key.pub) \
+		> $OBJ/authorized_keys_$USER
+	for t in ${SSH_KEYTYPES}; do
+		if [ "$t" != "ssh-dss" ]; then
+		trace "connect via agent using $t key"
+		${SSH} -F $OBJ/ssh_proxy -i $OBJ/$t-agent.pub \
+			-oCertificateFile=$OBJ/$t-agent-cert.pub \
+			-oIdentitiesOnly=yes somehost exit 52
+		r=$?
+		if [ $r -ne 52 ]; then
+			fail "ssh connect with failed (exit code $r)"
+		fi
+		fi
+	done
+
+	## Deletion tests.
+
+	trace "delete all agent keys"
+	${SSHADD} -D > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 0 ]; then
+		fail "ssh-add -D failed: exit code $r"
+	fi
+	# make sure they're gone
+	${SSHADD} -l > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 1 ]; then
+		fail "ssh-add -l returned unexpected exit code: $r"
+	fi
+	trace "readd keys"
+	# re-add keys/certs to agent
+	for t in ${SSH_KEYTYPES}; do
+		${SSHADD} $OBJ/$t-agent-private >/dev/null 2>&1 || \
+			fail "ssh-add failed exit code $?"
+	done
+	# make sure they are there
+	${SSHADD} -l > /dev/null 2>&1
+	r=$?
+	if [ $r -ne 0 ]; then
+		fail "ssh-add -l failed: exit code $r"
+	fi
+
+	check_key_absent() {
+		${SSHADD} -L | grep "^$1 " >/dev/null
+		if [ $? -eq 0 ]; then
+			fail "$1 key unexpectedly present"
+		fi
+	}
+	check_key_present() {
+		${SSHADD} -L | grep "^$1 " >/dev/null
+		if [ $? -ne 0 ]; then
+			fail "$1 key missing from agent"
+		fi
+	}
+
+	# delete the ed25519 key
+	trace "delete single key by file"
+	${SSHADD} -qdk $OBJ/ssh-ed25519-agent || fail "ssh-add -d ed25519 failed"
+	check_key_absent ssh-ed25519
+	check_key_present ssh-ed25519-cert-v01@openssh.com
+	# Put key/cert back.
+	${SSHADD} $OBJ/ssh-ed25519-agent-private >/dev/null 2>&1 || \
 		fail "ssh-add failed exit code $?"
-done
-# make sure they are there
-${SSHADD} -l > /dev/null 2>&1
-r=$?
-if [ $r -ne 0 ]; then
-	fail "ssh-add -l failed: exit code $r"
+	check_key_present ssh-ed25519
+	# Delete both key and certificate.
+	trace "delete key/cert by file"
+	${SSHADD} -qd $OBJ/ssh-ed25519-agent || fail "ssh-add -d ed25519 failed"
+	check_key_absent ssh-ed25519
+	check_key_absent ssh-ed25519-cert-v01@openssh.com
+	# Put key/cert back.
+	${SSHADD} $OBJ/ssh-ed25519-agent-private >/dev/null 2>&1 || \
+		fail "ssh-add failed exit code $?"
+	check_key_present ssh-ed25519
+	# Delete certificate via stdin
+	${SSHADD} -qd - < $OBJ/ssh-ed25519-agent-cert.pub || fail "ssh-add -d - failed"
+	check_key_present ssh-ed25519
+	check_key_absent ssh-ed25519-cert-v01@openssh.com
+	# Delete key via stdin
+	${SSHADD} -qd - < $OBJ/ssh-ed25519-agent.pub || fail "ssh-add -d - failed"
+	check_key_absent ssh-ed25519
+	check_key_absent ssh-ed25519-cert-v01@openssh.com
 fi
-
-check_key_absent() {
-	${SSHADD} -L | grep "^$1 " >/dev/null
-	if [ $? -eq 0 ]; then
-		fail "$1 key unexpectedly present"
-	fi
-}
-check_key_present() {
-	${SSHADD} -L | grep "^$1 " >/dev/null
-	if [ $? -ne 0 ]; then
-		fail "$1 key missing from agent"
-	fi
-}
-
-# delete the ed25519 key
-trace "delete single key by file"
-${SSHADD} -qdk $OBJ/ssh-ed25519-agent || fail "ssh-add -d ed25519 failed"
-check_key_absent ssh-ed25519
-check_key_present ssh-ed25519-cert-v01@openssh.com
-# Put key/cert back.
-${SSHADD} $OBJ/ssh-ed25519-agent-private >/dev/null 2>&1 || \
-	fail "ssh-add failed exit code $?"
-check_key_present ssh-ed25519
-# Delete both key and certificate.
-trace "delete key/cert by file"
-${SSHADD} -qd $OBJ/ssh-ed25519-agent || fail "ssh-add -d ed25519 failed"
-check_key_absent ssh-ed25519
-check_key_absent ssh-ed25519-cert-v01@openssh.com
-# Put key/cert back.
-${SSHADD} $OBJ/ssh-ed25519-agent-private >/dev/null 2>&1 || \
-	fail "ssh-add failed exit code $?"
-check_key_present ssh-ed25519
-# Delete certificate via stdin
-${SSHADD} -qd - < $OBJ/ssh-ed25519-agent-cert.pub || fail "ssh-add -d - failed"
-check_key_present ssh-ed25519
-check_key_absent ssh-ed25519-cert-v01@openssh.com
-# Delete key via stdin
-${SSHADD} -qd - < $OBJ/ssh-ed25519-agent.pub || fail "ssh-add -d - failed"
-check_key_absent ssh-ed25519
-check_key_absent ssh-ed25519-cert-v01@openssh.com
 
 trace "kill agent"
 ${SSHAGENT} -k > /dev/null

--- a/regress/cfgmatch.sh
+++ b/regress/cfgmatch.sh
@@ -1,183 +1,183 @@
 #	$OpenBSD: cfgmatch.sh,v 1.13 2021/06/08 06:52:43 djm Exp $
 #	Placed in the Public Domain.
 
-tid="sshd_config match"
+# tid="sshd_config match"
 
-pidfile=$OBJ/remote_pid
-fwdport=3301
-fwd="-L $fwdport:127.0.0.1:$PORT"
+# pidfile=$OBJ/remote_pid
+# fwdport=3301
+# fwd="-L $fwdport:127.0.0.1:$PORT"
 
-echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_config
-echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_proxy
+# echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_config
+# echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_proxy
 
-start_client()
-{
-	rm -f $pidfile
-	${SSH} -q $fwd "$@" somehost \
-	    exec sh -c \'"echo \$\$ > $pidfile; exec sleep 100"\' \
-	    >>$TEST_REGRESS_LOGFILE 2>&1 &
-	client_pid=$!
-	# Wait for remote end
-	n=0
-	while test ! -f $pidfile ; do
-		sleep 1
-		n=`expr $n + 1`
-		if test $n -gt 60; then
-			if [ "$os" == "windows" ]; then
-				# We can't kill windows process from cygwin / wsl so use "stop-process"
-				powershell.exe /c "stop-process -id $client_pid -Force" >/dev/null 2>&1
-			else
-				kill $client_pid
-			fi
-			fatal "timeout waiting for background ssh"
-		fi
-	done
-}
+# start_client()
+# {
+# 	rm -f $pidfile
+# 	${SSH} -q $fwd "$@" somehost \
+# 	    exec sh -c \'"echo \$\$ > $pidfile; exec sleep 100"\' \
+# 	    >>$TEST_REGRESS_LOGFILE 2>&1 &
+# 	client_pid=$!
+# 	# Wait for remote end
+# 	n=0
+# 	while test ! -f $pidfile ; do
+# 		sleep 1
+# 		n=`expr $n + 1`
+# 		if test $n -gt 60; then
+# 			if [ "$os" == "windows" ]; then
+# 				# We can't kill windows process from cygwin / wsl so use "stop-process"
+# 				powershell.exe /c "stop-process -id $client_pid -Force" >/dev/null 2>&1
+# 			else
+# 				kill $client_pid
+# 			fi
+# 			fatal "timeout waiting for background ssh"
+# 		fi
+# 	done
+# }
 
-stop_client()
-{
-	pid=`cat $pidfile`
-	if [ "$os" == "windows" ]; then
-		# We can't kill windows process from cygwin / wsl so use "stop-process"
-		powershell.exe /c "stop-process -id $pid -Force" >/dev/null 2>&1
-		powershell.exe /c "stop-process -name sleep -Force" >/dev/null 2>&1
-	else
-		if [ ! -z "$pid" ]; then
-			kill $pid
-		fi
-		wait
-	fi
-}
+# stop_client()
+# {
+# 	pid=`cat $pidfile`
+# 	if [ "$os" == "windows" ]; then
+# 		# We can't kill windows process from cygwin / wsl so use "stop-process"
+# 		powershell.exe /c "stop-process -id $pid -Force" >/dev/null 2>&1
+# 		powershell.exe /c "stop-process -name sleep -Force" >/dev/null 2>&1
+# 	else
+# 		if [ ! -z "$pid" ]; then
+# 			kill $pid
+# 		fi
+# 		wait
+# 	fi
+# }
 
-cp $OBJ/sshd_proxy $OBJ/sshd_proxy_bak
-echo "PermitOpen 127.0.0.1:1 # comment" >>$OBJ/sshd_config
-echo "Match Address 127.0.0.1" >>$OBJ/sshd_config
-echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_config
+# cp $OBJ/sshd_proxy $OBJ/sshd_proxy_bak
+# echo "PermitOpen 127.0.0.1:1 # comment" >>$OBJ/sshd_config
+# echo "Match Address 127.0.0.1" >>$OBJ/sshd_config
+# echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_config
 
-grep -v AuthorizedKeysFile $OBJ/sshd_proxy_bak > $OBJ/sshd_proxy
-echo "AuthorizedKeysFile /dev/null # comment" >>$OBJ/sshd_proxy
-echo "PermitOpen 127.0.0.1:1" >>$OBJ/sshd_proxy
-if [ "$os" == "windows" ]; then
-	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
-	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
-else
-	echo "Match user $USER" >>$OBJ/sshd_proxy
-fi
+# grep -v AuthorizedKeysFile $OBJ/sshd_proxy_bak > $OBJ/sshd_proxy
+# echo "AuthorizedKeysFile /dev/null # comment" >>$OBJ/sshd_proxy
+# echo "PermitOpen 127.0.0.1:1" >>$OBJ/sshd_proxy
+# if [ "$os" == "windows" ]; then
+# 	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
+# 	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
+# else
+# 	echo "Match user $USER" >>$OBJ/sshd_proxy
+# fi
 
-echo "AuthorizedKeysFile /dev/null $OBJ/authorized_keys_%u" >>$OBJ/sshd_proxy
-echo "Match Address 127.0.0.1 # comment" >>$OBJ/sshd_proxy
-echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_proxy
+# echo "AuthorizedKeysFile /dev/null $OBJ/authorized_keys_%u" >>$OBJ/sshd_proxy
+# echo "Match Address 127.0.0.1 # comment" >>$OBJ/sshd_proxy
+# echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_proxy
 
-${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
-    fail "config w/match fails config test"
+# ${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
+#     fail "config w/match fails config test"
 
-start_sshd
+# start_sshd
 
-# Test Match + PermitOpen in sshd_config.  This should be permitted
-trace "match permitopen localhost"
-start_client -F $OBJ/ssh_config
-${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
-    fail "match permitopen permit"
-stop_client
+# # Test Match + PermitOpen in sshd_config.  This should be permitted
+# trace "match permitopen localhost"
+# start_client -F $OBJ/ssh_config
+# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
+#     fail "match permitopen permit"
+# stop_client
 
-# Same but from different source.  This should not be permitted
-trace "match permitopen proxy"
-start_client -F $OBJ/ssh_proxy
-${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
-    fail "match permitopen deny"
-stop_client
+# # Same but from different source.  This should not be permitted
+# trace "match permitopen proxy"
+# start_client -F $OBJ/ssh_proxy
+# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
+#     fail "match permitopen deny"
+# stop_client
 
-# Retry previous with key option, should also be denied.
-cp /dev/null $OBJ/authorized_keys_$USER
-for t in ${SSH_KEYTYPES}; do
-	printf 'permitopen="127.0.0.1:'$PORT'" ' >> $OBJ/authorized_keys_$USER
-	cat $OBJ/$t.pub >> $OBJ/authorized_keys_$USER
-done
-trace "match permitopen proxy w/key opts"
-start_client -F $OBJ/ssh_proxy
-${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
-    fail "match permitopen deny w/key opt"
-stop_client
+# # Retry previous with key option, should also be denied.
+# cp /dev/null $OBJ/authorized_keys_$USER
+# for t in ${SSH_KEYTYPES}; do
+# 	printf 'permitopen="127.0.0.1:'$PORT'" ' >> $OBJ/authorized_keys_$USER
+# 	cat $OBJ/$t.pub >> $OBJ/authorized_keys_$USER
+# done
+# trace "match permitopen proxy w/key opts"
+# start_client -F $OBJ/ssh_proxy
+# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
+#     fail "match permitopen deny w/key opt"
+# stop_client
 
-# Test both sshd_config and key options permitting the same dst/port pair.
-# Should be permitted.
-trace "match permitopen localhost"
-start_client -F $OBJ/ssh_config
-${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
-    fail "match permitopen permit"
-stop_client
+# # Test both sshd_config and key options permitting the same dst/port pair.
+# # Should be permitted.
+# trace "match permitopen localhost"
+# start_client -F $OBJ/ssh_config
+# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
+#     fail "match permitopen permit"
+# stop_client
 
-cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
-echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
-if [ "$os" == "windows" ]; then
-	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
-	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
-else
-	echo "Match user $USER" >>$OBJ/sshd_proxy
-fi
-echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
+# cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
+# echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
+# if [ "$os" == "windows" ]; then
+# 	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
+# 	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
+# else
+# 	echo "Match user $USER" >>$OBJ/sshd_proxy
+# fi
+# echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
 
-# Test that a Match overrides a PermitOpen in the global section
-trace "match permitopen proxy w/key opts"
-start_client -F $OBJ/ssh_proxy
-${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
-    fail "match override permitopen"
-stop_client
+# # Test that a Match overrides a PermitOpen in the global section
+# trace "match permitopen proxy w/key opts"
+# start_client -F $OBJ/ssh_proxy
+# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
+#     fail "match override permitopen"
+# stop_client
 
-cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
-echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
-echo "Match User NoSuchUser" >>$OBJ/sshd_proxy
-echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
+# cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
+# echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
+# echo "Match User NoSuchUser" >>$OBJ/sshd_proxy
+# echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
 
-# Test that a rule that doesn't match doesn't override, plus test a
-# PermitOpen entry that's not at the start of the list
-trace "nomatch permitopen proxy w/key opts"
-start_client -F $OBJ/ssh_proxy
-${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
-    fail "nomatch override permitopen"
-stop_client
+# # Test that a rule that doesn't match doesn't override, plus test a
+# # PermitOpen entry that's not at the start of the list
+# trace "nomatch permitopen proxy w/key opts"
+# start_client -F $OBJ/ssh_proxy
+# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
+#     fail "nomatch override permitopen"
+# stop_client
 
-# Test parsing of available Match criteria (with the exception of Group which
-# requires knowledge of actual group memberships user running the test).
-params="user:user:u1 host:host:h1 address:addr:1.2.3.4 \
-    localaddress:laddr:5.6.7.8 rdomain:rdomain:rdom1"
-cp $OBJ/sshd_proxy_bak $OBJ/sshd_config
-echo 'Banner /nomatch' >>$OBJ/sshd_config
-for i in $params; do
-	config=`echo $i | cut -f1 -d:`
-	criteria=`echo $i | cut -f2 -d:`
-	value=`echo $i | cut -f3 -d:`
-	cat >>$OBJ/sshd_config <<EOD
-	    Match $config $value
-	      Banner /$value
-EOD
-done
+# # Test parsing of available Match criteria (with the exception of Group which
+# # requires knowledge of actual group memberships user running the test).
+# params="user:user:u1 host:host:h1 address:addr:1.2.3.4 \
+#     localaddress:laddr:5.6.7.8 rdomain:rdomain:rdom1"
+# cp $OBJ/sshd_proxy_bak $OBJ/sshd_config
+# echo 'Banner /nomatch' >>$OBJ/sshd_config
+# for i in $params; do
+# 	config=`echo $i | cut -f1 -d:`
+# 	criteria=`echo $i | cut -f2 -d:`
+# 	value=`echo $i | cut -f3 -d:`
+# 	cat >>$OBJ/sshd_config <<EOD
+# 	    Match $config $value
+# 	      Banner /$value
+# EOD
+# done
 
-${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
-    fail "validate config for w/out spec"
+# ${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
+#     fail "validate config for w/out spec"
 
-# Test matching each criteria.
-for i in $params; do
-	testcriteria=`echo $i | cut -f2 -d:`
-	expected=/`echo $i | cut -f3 -d:`
-	spec=""
-	for j in $params; do
-		config=`echo $j | cut -f1 -d:`
-		criteria=`echo $j | cut -f2 -d:`
-		value=`echo $j | cut -f3 -d:`
-		if [ "$criteria" = "$testcriteria" ]; then
-			spec="$criteria=$value,$spec"
-		else
-			spec="$criteria=1$value,$spec"
-		fi
-	done
-	trace "test spec $spec"
-	result=`${SUDO} ${SSHD} -f $OBJ/sshd_config -T -C "$spec" | \
-	    awk '$1=="banner"{print $2}'`
-	if [ "$os" == "windows" ]; then
-		result=${result/$'\r'/} # remove CR (carriage return)
-	fi
-	if [ "$result" != "$expected" ]; then
-		fail "match $config expected $expected got $result"
-	fi
-done
+# # Test matching each criteria.
+# for i in $params; do
+# 	testcriteria=`echo $i | cut -f2 -d:`
+# 	expected=/`echo $i | cut -f3 -d:`
+# 	spec=""
+# 	for j in $params; do
+# 		config=`echo $j | cut -f1 -d:`
+# 		criteria=`echo $j | cut -f2 -d:`
+# 		value=`echo $j | cut -f3 -d:`
+# 		if [ "$criteria" = "$testcriteria" ]; then
+# 			spec="$criteria=$value,$spec"
+# 		else
+# 			spec="$criteria=1$value,$spec"
+# 		fi
+# 	done
+# 	trace "test spec $spec"
+# 	result=`${SUDO} ${SSHD} -f $OBJ/sshd_config -T -C "$spec" | \
+# 	    awk '$1=="banner"{print $2}'`
+# 	if [ "$os" == "windows" ]; then
+# 		result=${result/$'\r'/} # remove CR (carriage return)
+# 	fi
+# 	if [ "$result" != "$expected" ]; then
+# 		fail "match $config expected $expected got $result"
+# 	fi
+# done

--- a/regress/cfgmatch.sh
+++ b/regress/cfgmatch.sh
@@ -1,183 +1,183 @@
-#	$OpenBSD: cfgmatch.sh,v 1.13 2021/06/08 06:52:43 djm Exp $
-#	Placed in the Public Domain.
+	$OpenBSD: cfgmatch.sh,v 1.13 2021/06/08 06:52:43 djm Exp $
+	Placed in the Public Domain.
 
-# tid="sshd_config match"
+tid="sshd_config match"
 
-# pidfile=$OBJ/remote_pid
-# fwdport=3301
-# fwd="-L $fwdport:127.0.0.1:$PORT"
+pidfile=$OBJ/remote_pid
+fwdport=3301
+fwd="-L $fwdport:127.0.0.1:$PORT"
 
-# echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_config
-# echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_proxy
+echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_config
+echo "ExitOnForwardFailure=yes" >> $OBJ/ssh_proxy
 
-# start_client()
-# {
-# 	rm -f $pidfile
-# 	${SSH} -q $fwd "$@" somehost \
-# 	    exec sh -c \'"echo \$\$ > $pidfile; exec sleep 100"\' \
-# 	    >>$TEST_REGRESS_LOGFILE 2>&1 &
-# 	client_pid=$!
-# 	# Wait for remote end
-# 	n=0
-# 	while test ! -f $pidfile ; do
-# 		sleep 1
-# 		n=`expr $n + 1`
-# 		if test $n -gt 60; then
-# 			if [ "$os" == "windows" ]; then
-# 				# We can't kill windows process from cygwin / wsl so use "stop-process"
-# 				powershell.exe /c "stop-process -id $client_pid -Force" >/dev/null 2>&1
-# 			else
-# 				kill $client_pid
-# 			fi
-# 			fatal "timeout waiting for background ssh"
-# 		fi
-# 	done
-# }
+start_client()
+{
+	rm -f $pidfile
+	${SSH} -q $fwd "$@" somehost \
+	    exec sh -c \'"echo \$\$ > $pidfile; exec sleep 100"\' \
+	    >>$TEST_REGRESS_LOGFILE 2>&1 &
+	client_pid=$!
+	# Wait for remote end
+	n=0
+	while test ! -f $pidfile ; do
+		sleep 1
+		n=`expr $n + 1`
+		if test $n -gt 60; then
+			if [ "$os" == "windows" ]; then
+				# We can't kill windows process from cygwin / wsl so use "stop-process"
+				powershell.exe /c "stop-process -id $client_pid -Force" >/dev/null 2>&1
+			else
+				kill $client_pid
+			fi
+			fatal "timeout waiting for background ssh"
+		fi
+	done
+}
 
-# stop_client()
-# {
-# 	pid=`cat $pidfile`
-# 	if [ "$os" == "windows" ]; then
-# 		# We can't kill windows process from cygwin / wsl so use "stop-process"
-# 		powershell.exe /c "stop-process -id $pid -Force" >/dev/null 2>&1
-# 		powershell.exe /c "stop-process -name sleep -Force" >/dev/null 2>&1
-# 	else
-# 		if [ ! -z "$pid" ]; then
-# 			kill $pid
-# 		fi
-# 		wait
-# 	fi
-# }
+stop_client()
+{
+	pid=`cat $pidfile`
+	if [ "$os" == "windows" ]; then
+		# We can't kill windows process from cygwin / wsl so use "stop-process"
+		powershell.exe /c "stop-process -id $pid -Force" >/dev/null 2>&1
+		powershell.exe /c "stop-process -name sleep -Force" >/dev/null 2>&1
+	else
+		if [ ! -z "$pid" ]; then
+			kill $pid
+		fi
+		wait
+	fi
+}
 
-# cp $OBJ/sshd_proxy $OBJ/sshd_proxy_bak
-# echo "PermitOpen 127.0.0.1:1 # comment" >>$OBJ/sshd_config
-# echo "Match Address 127.0.0.1" >>$OBJ/sshd_config
-# echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_config
+cp $OBJ/sshd_proxy $OBJ/sshd_proxy_bak
+echo "PermitOpen 127.0.0.1:1 # comment" >>$OBJ/sshd_config
+echo "Match Address 127.0.0.1" >>$OBJ/sshd_config
+echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_config
 
-# grep -v AuthorizedKeysFile $OBJ/sshd_proxy_bak > $OBJ/sshd_proxy
-# echo "AuthorizedKeysFile /dev/null # comment" >>$OBJ/sshd_proxy
-# echo "PermitOpen 127.0.0.1:1" >>$OBJ/sshd_proxy
-# if [ "$os" == "windows" ]; then
-# 	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
-# 	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
-# else
-# 	echo "Match user $USER" >>$OBJ/sshd_proxy
-# fi
+grep -v AuthorizedKeysFile $OBJ/sshd_proxy_bak > $OBJ/sshd_proxy
+echo "AuthorizedKeysFile /dev/null # comment" >>$OBJ/sshd_proxy
+echo "PermitOpen 127.0.0.1:1" >>$OBJ/sshd_proxy
+if [ "$os" == "windows" ]; then
+	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
+	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
+else
+	echo "Match user $USER" >>$OBJ/sshd_proxy
+fi
 
-# echo "AuthorizedKeysFile /dev/null $OBJ/authorized_keys_%u" >>$OBJ/sshd_proxy
-# echo "Match Address 127.0.0.1 # comment" >>$OBJ/sshd_proxy
-# echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_proxy
+echo "AuthorizedKeysFile /dev/null $OBJ/authorized_keys_%u" >>$OBJ/sshd_proxy
+echo "Match Address 127.0.0.1 # comment" >>$OBJ/sshd_proxy
+echo "PermitOpen 127.0.0.1:2 127.0.0.1:3 127.0.0.1:$PORT" >>$OBJ/sshd_proxy
 
-# ${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
-#     fail "config w/match fails config test"
+${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
+    fail "config w/match fails config test"
 
-# start_sshd
+start_sshd
 
-# # Test Match + PermitOpen in sshd_config.  This should be permitted
-# trace "match permitopen localhost"
-# start_client -F $OBJ/ssh_config
-# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
-#     fail "match permitopen permit"
-# stop_client
+# Test Match + PermitOpen in sshd_config.  This should be permitted
+trace "match permitopen localhost"
+start_client -F $OBJ/ssh_config
+${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
+    fail "match permitopen permit"
+stop_client
 
-# # Same but from different source.  This should not be permitted
-# trace "match permitopen proxy"
-# start_client -F $OBJ/ssh_proxy
-# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
-#     fail "match permitopen deny"
-# stop_client
+# Same but from different source.  This should not be permitted
+trace "match permitopen proxy"
+start_client -F $OBJ/ssh_proxy
+${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
+    fail "match permitopen deny"
+stop_client
 
-# # Retry previous with key option, should also be denied.
-# cp /dev/null $OBJ/authorized_keys_$USER
-# for t in ${SSH_KEYTYPES}; do
-# 	printf 'permitopen="127.0.0.1:'$PORT'" ' >> $OBJ/authorized_keys_$USER
-# 	cat $OBJ/$t.pub >> $OBJ/authorized_keys_$USER
-# done
-# trace "match permitopen proxy w/key opts"
-# start_client -F $OBJ/ssh_proxy
-# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
-#     fail "match permitopen deny w/key opt"
-# stop_client
+# Retry previous with key option, should also be denied.
+cp /dev/null $OBJ/authorized_keys_$USER
+for t in ${SSH_KEYTYPES}; do
+	printf 'permitopen="127.0.0.1:'$PORT'" ' >> $OBJ/authorized_keys_$USER
+	cat $OBJ/$t.pub >> $OBJ/authorized_keys_$USER
+done
+trace "match permitopen proxy w/key opts"
+start_client -F $OBJ/ssh_proxy
+${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
+    fail "match permitopen deny w/key opt"
+stop_client
 
-# # Test both sshd_config and key options permitting the same dst/port pair.
-# # Should be permitted.
-# trace "match permitopen localhost"
-# start_client -F $OBJ/ssh_config
-# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
-#     fail "match permitopen permit"
-# stop_client
+# Test both sshd_config and key options permitting the same dst/port pair.
+# Should be permitted.
+trace "match permitopen localhost"
+start_client -F $OBJ/ssh_config
+${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
+    fail "match permitopen permit"
+stop_client
 
-# cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
-# echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
-# if [ "$os" == "windows" ]; then
-# 	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
-# 	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
-# else
-# 	echo "Match user $USER" >>$OBJ/sshd_proxy
-# fi
-# echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
+cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
+echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
+if [ "$os" == "windows" ]; then
+	# If User is domainuser then it will be in "domain/user" so convert it to "domain\user"
+	echo "Match user ${USER//\//\\}" >>$OBJ/sshd_proxy
+else
+	echo "Match user $USER" >>$OBJ/sshd_proxy
+fi
+echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
 
-# # Test that a Match overrides a PermitOpen in the global section
-# trace "match permitopen proxy w/key opts"
-# start_client -F $OBJ/ssh_proxy
-# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
-#     fail "match override permitopen"
-# stop_client
+# Test that a Match overrides a PermitOpen in the global section
+trace "match permitopen proxy w/key opts"
+start_client -F $OBJ/ssh_proxy
+${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true && \
+    fail "match override permitopen"
+stop_client
 
-# cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
-# echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
-# echo "Match User NoSuchUser" >>$OBJ/sshd_proxy
-# echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
+cp $OBJ/sshd_proxy_bak $OBJ/sshd_proxy
+echo "PermitOpen 127.0.0.1:1 127.0.0.1:$PORT 127.0.0.2:2" >>$OBJ/sshd_proxy
+echo "Match User NoSuchUser" >>$OBJ/sshd_proxy
+echo "PermitOpen 127.0.0.1:1 127.0.0.1:2" >>$OBJ/sshd_proxy
 
-# # Test that a rule that doesn't match doesn't override, plus test a
-# # PermitOpen entry that's not at the start of the list
-# trace "nomatch permitopen proxy w/key opts"
-# start_client -F $OBJ/ssh_proxy
-# ${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
-#     fail "nomatch override permitopen"
-# stop_client
+# Test that a rule that doesn't match doesn't override, plus test a
+# PermitOpen entry that's not at the start of the list
+trace "nomatch permitopen proxy w/key opts"
+start_client -F $OBJ/ssh_proxy
+${SSH} -q -p $fwdport -F $OBJ/ssh_config somehost true || \
+    fail "nomatch override permitopen"
+stop_client
 
-# # Test parsing of available Match criteria (with the exception of Group which
-# # requires knowledge of actual group memberships user running the test).
-# params="user:user:u1 host:host:h1 address:addr:1.2.3.4 \
-#     localaddress:laddr:5.6.7.8 rdomain:rdomain:rdom1"
-# cp $OBJ/sshd_proxy_bak $OBJ/sshd_config
-# echo 'Banner /nomatch' >>$OBJ/sshd_config
-# for i in $params; do
-# 	config=`echo $i | cut -f1 -d:`
-# 	criteria=`echo $i | cut -f2 -d:`
-# 	value=`echo $i | cut -f3 -d:`
-# 	cat >>$OBJ/sshd_config <<EOD
-# 	    Match $config $value
-# 	      Banner /$value
-# EOD
-# done
+# Test parsing of available Match criteria (with the exception of Group which
+# requires knowledge of actual group memberships user running the test).
+params="user:user:u1 host:host:h1 address:addr:1.2.3.4 \
+    localaddress:laddr:5.6.7.8 rdomain:rdomain:rdom1"
+cp $OBJ/sshd_proxy_bak $OBJ/sshd_config
+echo 'Banner /nomatch' >>$OBJ/sshd_config
+for i in $params; do
+	config=`echo $i | cut -f1 -d:`
+	criteria=`echo $i | cut -f2 -d:`
+	value=`echo $i | cut -f3 -d:`
+	cat >>$OBJ/sshd_config <<EOD
+	    Match $config $value
+	      Banner /$value
+EOD
+done
 
-# ${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
-#     fail "validate config for w/out spec"
+${SUDO} ${SSHD} -f $OBJ/sshd_config -T >/dev/null || \
+    fail "validate config for w/out spec"
 
-# # Test matching each criteria.
-# for i in $params; do
-# 	testcriteria=`echo $i | cut -f2 -d:`
-# 	expected=/`echo $i | cut -f3 -d:`
-# 	spec=""
-# 	for j in $params; do
-# 		config=`echo $j | cut -f1 -d:`
-# 		criteria=`echo $j | cut -f2 -d:`
-# 		value=`echo $j | cut -f3 -d:`
-# 		if [ "$criteria" = "$testcriteria" ]; then
-# 			spec="$criteria=$value,$spec"
-# 		else
-# 			spec="$criteria=1$value,$spec"
-# 		fi
-# 	done
-# 	trace "test spec $spec"
-# 	result=`${SUDO} ${SSHD} -f $OBJ/sshd_config -T -C "$spec" | \
-# 	    awk '$1=="banner"{print $2}'`
-# 	if [ "$os" == "windows" ]; then
-# 		result=${result/$'\r'/} # remove CR (carriage return)
-# 	fi
-# 	if [ "$result" != "$expected" ]; then
-# 		fail "match $config expected $expected got $result"
-# 	fi
-# done
+# Test matching each criteria.
+for i in $params; do
+	testcriteria=`echo $i | cut -f2 -d:`
+	expected=/`echo $i | cut -f3 -d:`
+	spec=""
+	for j in $params; do
+		config=`echo $j | cut -f1 -d:`
+		criteria=`echo $j | cut -f2 -d:`
+		value=`echo $j | cut -f3 -d:`
+		if [ "$criteria" = "$testcriteria" ]; then
+			spec="$criteria=$value,$spec"
+		else
+			spec="$criteria=1$value,$spec"
+		fi
+	done
+	trace "test spec $spec"
+	result=`${SUDO} ${SSHD} -f $OBJ/sshd_config -T -C "$spec" | \
+	    awk '$1=="banner"{print $2}'`
+	if [ "$os" == "windows" ]; then
+		result=${result/$'\r'/} # remove CR (carriage return)
+	fi
+	if [ "$result" != "$expected" ]; then
+		fail "match $config expected $expected got $result"
+	fi
+done

--- a/regress/cfgmatch.sh
+++ b/regress/cfgmatch.sh
@@ -1,5 +1,5 @@
-	$OpenBSD: cfgmatch.sh,v 1.13 2021/06/08 06:52:43 djm Exp $
-	Placed in the Public Domain.
+#	$OpenBSD: cfgmatch.sh,v 1.13 2021/06/08 06:52:43 djm Exp $
+#	Placed in the Public Domain.
 
 tid="sshd_config match"
 

--- a/regress/test-exec.sh
+++ b/regress/test-exec.sh
@@ -633,8 +633,8 @@ Host *
 	HostKeyAlias		localhost-with-alias
 	Port			$PORT
 	User			$USER
-	GlobalKnownHostsFile	$OBJ/known_hosts
-	UserKnownHostsFile	$OBJ/known_hosts
+	GlobalKnownHostsFile	`windows_path $OBJ/known_hosts`
+	UserKnownHostsFile	`windows_path $OBJ/known_hosts`
 	PubkeyAuthentication	yes
 	ChallengeResponseAuthentication	no
 	PasswordAuthentication	no
@@ -685,6 +685,7 @@ if [ "$os" == "windows" ]; then
 	SSH_KEYTYPES=`echo $SSH_KEYTYPES | tr -d '\r','\n'`  # remove \r\n
 	SSH_HOSTKEY_TYPES=`echo $SSH_HOSTKEY_TYPES | tr -d '\r','\n'`  # remove \r\n
 	OBJ_WIN_FORMAT=`windows_path $OBJ`
+	SRC_WIN_FORMAT=`windows_path $SRC`
 	first_key_type=${SSH_KEYTYPES%% *}
 	if [ "x$USER_DOMAIN" != "x" ]; then
 		# For domain user, create folders
@@ -733,8 +734,12 @@ for t in ${SSH_HOSTKEY_TYPES}; do
 
 	echo HostKey $OBJ/host.$t >> $OBJ/sshd_config
 
-	# don't use SUDO for proxy connect
-	echo HostKey $OBJ/$t >> $OBJ/sshd_proxy
+	if [ "$os" == "windows" ]; then
+		echo HostKey `windows_path $OBJ/$t` >> $OBJ/sshd_proxy
+	else
+		# don't use SUDO for proxy connect
+		echo HostKey $OBJ/$t >> $OBJ/sshd_proxy
+	fi
 done
 
 if [ "$os" == "windows" ]; then
@@ -804,7 +809,7 @@ fi
 	if [ "$os" == "windows" ]; then
 		# TODO - having SSH_SK_HELPER is causing issues. Need to find a way.
 		# This is fine for now as we don't have FIDO enabled.
-		echo proxycommand  `windows_path ${SSHD}` -i -f $OBJ_WIN_FORMAT/sshd_proxy
+		echo proxycommand  `windows_path ${SSHD}` -i -f `windows_path $OBJ`/sshd_proxy
 	else
 		echo proxycommand ${SUDO} env SSH_SK_HELPER=\"$SSH_SK_HELPER\" sh ${SRC}/sshd-log-wrapper.sh ${TEST_SSHD_LOGFILE} ${SSHD} -i -f $OBJ/sshd_proxy
 	fi

--- a/session.c
+++ b/session.c
@@ -198,8 +198,15 @@ auth_input_request_forwarding(struct ssh *ssh, struct passwd * pw)
 	/* Temporarily drop privileged uid for mkdir/bind. */
 	temporarily_use_uid(pw);
 
+#ifdef WINDOWS
+	/* Allocate a buffer for the socket name, and format the name. */
+	auth_sock_dir = xstrdup("C:\\tmp\\ssh-XXXXXXXXXX");
+
+#else
 	/* Allocate a buffer for the socket name, and format the name. */
 	auth_sock_dir = xstrdup("/tmp/ssh-XXXXXXXXXX");
+#endif
+
 
 	/* Create private directory for socket */
 	if (mkdtemp(auth_sock_dir) == NULL) {
@@ -211,8 +218,13 @@ auth_input_request_forwarding(struct ssh *ssh, struct passwd * pw)
 		goto authsock_err;
 	}
 
+#ifdef WINDOWS
+	xasprintf(&auth_sock_name, "%s\\agent.%ld",
+		auth_sock_dir, (long)getpid());
+#else
 	xasprintf(&auth_sock_name, "%s/agent.%ld",
-	    auth_sock_dir, (long) getpid());
+		auth_sock_dir, (long)getpid());
+#endif
 
 	/* Start a Unix listener on auth_sock_name. */
 	sock = unix_listener(auth_sock_name, SSH_LISTEN_BACKLOG, 0);


### PR DESCRIPTION
# PR Summary

This pull requests adds support for AF_UNIX sockets.

The implementation modifies contrib/win32/win32compat/socketio.c `socketio_acceptEx` implementation so that it can handle `sa_family == AF_UNIX`. contrib/win32/win32compat/w32fd.c has also been modified in order to remove the path that uses `fileio_afunix_socket`.

The unix socket name is conditionally using `C:\\tmp\\ssh-XXXXXXXXXX` instead of `/tmp/ssh-XXXXXXXXXX` since it doesn't work correctly when using `ssh` in the windows host. I'm not sure if `/tmp` is the best directory to host the sock in Windows but I left it that way since unix users will expect the agent socks to live there. The caveat here is that you need to create the `/tmp` folder in Windows in order to properly work.

One known gap that the implementation is missing is conditionally using AF_UNIX. I know that a subset of Windows version support it but I'm not sure what is the best way to handle this. If I can get any guidance in terms of how to approach it I can test it and modify it.

## PR Context

The motivation around working on this patch was to get support for SSH Agent Forwarding. With this patch applied, `ssh-add -l` will list the keys from the local system. I've also tested using `git` to clone repositories and it's successfully able to use the local system private keys through the agent. 

I've also tested that WSL can successfully use the SSH Agent sock as long as the `SSH_AUTH_SOCK` is defined in the bash session. 

This pull request could potentially solve the following issues:

https://github.com/PowerShell/Win32-OpenSSH/issues/1461
https://github.com/PowerShell/Win32-OpenSSH/issues/1761
https://github.com/PowerShell/Win32-OpenSSH/issues/1462
