### PR TITLE
Fix openbsd-compat/arc4random.c

### DIFF
--- a/openbsd-compat/arc4random.c
+++ b/openbsd-compat/arc4random.c
@@ -97,6 +97,7 @@ _rs_init(u_char *buf, size_t n)
 {
 	if (n < KEYSZ + IVSZ)
 		return;
+}
 
 #ifndef WITH_OPENSSL
 #ifdef WINDOWS


### PR DESCRIPTION
Add trailing curly brace to _rs_init() definition.