### PR TITLE
fix session id2 datetype missmatch

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -164,7 +164,7 @@ static char *hostbased_cuser = NULL;
 static char *hostbased_chost = NULL;
 static char *auth_method = "unknown";
 static char *auth_submethod = NULL;
-static u_int session_id2_len = 0;
+static size_t session_id2_len = 0;
 static u_char *session_id2 = NULL;
 static pid_t monitor_child_pid;
 

--- a/monitor.c
+++ b/monitor.c
@@ -164,7 +164,11 @@ static char *hostbased_cuser = NULL;
 static char *hostbased_chost = NULL;
 static char *auth_method = "unknown";
 static char *auth_submethod = NULL;
+#ifdef WINDOWS
 static size_t session_id2_len = 0;
+#else
+static u_int session_id2_len = 0;
+#endif /* WINDOWS */
 static u_char *session_id2 = NULL;
 static pid_t monitor_child_pid;
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fix session_id2_len data type mismatch when passing as a pointer.


## PR Context

The data type of `session_id2_len` is u_int. In `monitor.c`, it passed as a pointer to the function `sshbuf_get_string` and write 0 to the pointer. When running on x64 system, it cause other values override and cause 0xc0000005 error. 
This PR make the data type consistently. 

It seems that the issue is not exists in the original openssh repo.


-----
https://github.com/PowerShell/openssh-portable/blob/41e17111941aa8ec97c42abe8f1006c38dd95e43/sshbuf-getput-basic.c#L200-L209

https://github.com/PowerShell/openssh-portable/blob/41e17111941aa8ec97c42abe8f1006c38dd95e43/monitor.c#L1773
