### PR TITLE
Fix unreasonably small DefaultShellCommandOption size limit

### DIFF
--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -60,7 +60,7 @@ set_defaultshell()
 	HKEY reg_key = 0;
 	int tmp_len, ret = -1;
 	REGSAM mask = STANDARD_RIGHTS_READ | KEY_QUERY_VALUE | KEY_WOW64_64KEY;
-	wchar_t path_buf[PATH_MAX], option_buf[32], arg_buf[PATH_MAX];
+	wchar_t path_buf[PATH_MAX], option_buf[PATH_MAX], arg_buf[PATH_MAX];
 	char *pw_shellpath_local = NULL, *command_option_local = NULL, *shell_arguments_local = NULL;
 
 	errno = 0;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

<!-- Summarize your PR between here and the checklist. -->

The `DefaultShellCommandOption` registry key has a size limit of 15 characters. This seems unreasonably small especially since `DefaultShellArguments` has a much larger limit and its contents are not used for a non-interactive shell, so a lot of what is in there has to be duplicated.

For instance, if I wanted to configure OpenSSH to use MSYS2 without creating a helper script, this is what my registry keys would look like:

```
DefaultShell                 C:\msys64\msys2_shell.cmd
DefaultShellArguments        -defterm -mingw64 -no-start -shell zsh
DefaultShellCommandOption    -defterm -mingw64 -no-start -shell zsh -c
DefaultShellEscapeArguments  0
```

This PR increases the limit to the same value as `DefaultShellArguments`, which is currently `PATH_MAX / 2 - 1`.