### PR TITLE
add check for prog data folder permissions during sshd service startup

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -60,6 +60,7 @@
 #include "w32fd.h"
 #include "inc\string.h"
 #include "inc\time.h"
+#include "..\..\..\sshfileperm.h"
 
 #include <wchar.h>
 
@@ -1440,6 +1441,13 @@ create_directory_withsddl(wchar_t *path_w, wchar_t *sddl_w)
 		sa.lpSecurityDescriptor = pSD;
 		if (!CreateDirectoryW(path_w, &sa)) {
 			error("Failed to create directory:%ls error:%d", path_w, GetLastError());
+			return -1;
+		}
+	}
+	else {
+		// directory already exists; need to confirm permissions are correct
+		if (check_secure_folder_permission(path_w, 1) != 0) {
+			error("Directory already exists but folder permissions are invalid");
 			return -1;
 		}
 	}

--- a/sshfileperm.h
+++ b/sshfileperm.h
@@ -26,4 +26,5 @@
 #define _SSH_FILE_PERM_H
 
 int check_secure_file_permission(const char *, struct passwd *, int);
+int check_secure_folder_permission(const wchar_t*, int);
 #endif /* _SSH_FILE_PERM_H */


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- add method to check `ProgramData` folder permissions
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- during SSHD service startup, the folder permissions of an existing `ProgramData` folder should be verified, similar to the current functionality in the install scripts
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
