### PR TITLE
remove redundant WINDOWS preprocessor definitions

### DIFF
--- a/ssh-pkcs11-client.c
+++ b/ssh-pkcs11-client.c
@@ -165,20 +165,14 @@ find_helper(void)
 	char module_path[PATH_MAX + 1];
 	char *ep;
 	DWORD n;
-
-#ifdef WINDOWS
 	size_t len = 0;
+	
 	_dupenv_s(&helper, &len, "SSH_PKCS11_HELPER");
 	if (helper == NULL || len == 0) {
 		if ((helper = find_helper_in_module_path()) == NULL)
 			helper = _PATH_SSH_PKCS11_HELPER;
 	}
-#else
-	if ((helper = getenv("SSH_PKCS11_HELPER")) == NULL || strlen(helper) == 0) {
-		if ((helper = find_helper_in_module_path()) == NULL)
-			helper = _PATH_SSH_PKCS11_HELPER;
-	}
-#endif /* WINDOWS */
+
 	if (!path_absolute(helper)) {
 		error_f("helper \"%s\" unusable: path not absolute", helper);
 		return NULL;

--- a/ssh-sk-client.c
+++ b/ssh-sk-client.c
@@ -84,20 +84,14 @@ find_helper(void)
 	char module_path[PATH_MAX + 1];
 	char *ep;
 	DWORD n;
-
-#ifdef WINDOWS
 	size_t len = 0;
+
 	_dupenv_s(&helper, &len, "SSH_SK_HELPER");
 	if (helper == NULL || len == 0) {
 		if ((helper = find_helper_in_module_path()) == NULL)
 			helper = _PATH_SSH_SK_HELPER;
 	}
-#else
-	if ((helper = getenv("SSH_SK_HELPER")) == NULL || strlen(helper) == 0) {
-		if ((helper = find_helper_in_module_path()) == NULL)
-			helper = _PATH_SSH_SK_HELPER;
-	}
-#endif /* WINDOWS */
+
 	if (!path_absolute(helper)) {
 		error_f("helper \"%s\" unusable: path not absolute", helper);
 		return NULL;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
 - remove redundant preprocessor definitions since code is already encapsulated in a WINDOWS preprocessor definition
<!-- Summarize your PR between here and the checklist. -->
