### PR TITLE
disable adding pkcs11 providers to ssh-agent remotely

### DIFF
--- a/contrib/win32/win32compat/ssh-agent/agent-main.c
+++ b/contrib/win32/win32compat/ssh-agent/agent-main.c
@@ -37,6 +37,8 @@
 
 #pragma warning(push, 3)
 
+int remote_add_provider;
+
 int scm_start_service(DWORD, LPWSTR*);
 
 SERVICE_TABLE_ENTRYW dispatch_table[] =
@@ -116,42 +118,63 @@ fix_cwd()
 extern void sanitise_stdfd(void);
 
 int 
-wmain(int argc, wchar_t **argv) 
+wmain(int argc, wchar_t **wargv)
 {
 	_set_invalid_parameter_handler(invalid_parameter_handler);
 	w32posix_initialize();
 	fix_cwd();
+	/* Check if -Oallow-remote-pkcs11 has been passed in for all scenarios */
+	if (argc >= 2) {
+		for (int i = 0; i < argc; i++) {
+			if (wcsncmp(wargv[i], L"-O", 2) == 0) {
+				if (wcsncmp(wargv[i], L"-Oallow-remote-pkcs11", 21) == 0) {
+					remote_add_provider = 1;
+				}
+				else {
+					fatal("Unknown -O option; only allow-remote-pkcs11 is supported");
+				}
+			}
+		}
+	}
 	if (!StartServiceCtrlDispatcherW(dispatch_table)) {
 		if (GetLastError() == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
 			/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null */
 			sanitise_stdfd();
 
-			/* 
-			 * agent is not spawned by SCM 
-			 * Its either started in debug mode or a worker child 
+			/*
+			 * agent is not spawned by SCM
+			 * Its either started in debug mode or a worker child
+			 * If running in debug mode, args are (any order): -d, -dd, or -ddd and -Oallow-remote-pkcs11 (optional)
+			 * If a worker child, args are (in this order): int (connection handle) and -Oallow-remote-pkcs11 (optional) 
 			 */
-			if (argc == 2) {
-				if (wcsncmp(argv[1], L"-ddd", 4) == 0)
-					log_init("ssh-agent", 7, 1, 1);
-				else if (wcsncmp(argv[1], L"-dd", 3) == 0)
-					log_init("ssh-agent", 6, 1, 1);
-				else if (wcsncmp(argv[1], L"-d", 2) == 0)
-					log_init("ssh-agent", 5, 1, 1);
 
-				/* Set Ctrl+C handler if starting in debug mode */
-				if (wcsncmp(argv[1], L"-d", 2) == 0) {
-					SetConsoleCtrlHandler(ctrl_c_handler, TRUE);
-					agent_start(TRUE);
-					return 0;
-				}
+			if (argc >= 2) {
+				for (int i = 0; i < argc; i++) {
+					if (wcsncmp(wargv[i], L"-ddd", 4) == 0) {
+						log_init("ssh-agent", 7, 1, 1);
+					}
+					else if (wcsncmp(wargv[i], L"-dd", 3) == 0) {
+						log_init("ssh-agent", 6, 1, 1);
+					}
+					else if (wcsncmp(wargv[i], L"-d", 2) == 0) {
+						log_init("ssh-agent", 5, 1, 1);
+					}
 
-				/*agent process is likely a spawned child*/
-				char* h = 0;
-				h += _wtoi(*(argv + 1));
-				if (h != 0) {
-					log_init("ssh-agent", 3, 1, 0);
-					agent_process_connection(h);
-					return 0;
+					/* Set Ctrl+C handler if starting in debug mode */
+					if (wcsncmp(wargv[i], L"-d", 2) == 0) {
+						SetConsoleCtrlHandler(ctrl_c_handler, TRUE);
+						agent_start(TRUE);
+						return 0;
+					}
+
+					/*agent process is likely a spawned child*/
+					char* h = 0;
+					h += _wtoi(*(wargv + i));
+					if (h != 0) {
+						log_init("ssh-agent", 3, 1, 0);
+						agent_process_connection(h);
+						return 0;
+					}
 				}
 			}
 			/* to support linux compat scenarios where ssh-agent.exe is typically launched per session*/

--- a/contrib/win32/win32compat/ssh-agent/keyagent-request.c
+++ b/contrib/win32/win32compat/ssh-agent/keyagent-request.c
@@ -44,6 +44,8 @@
 #define MAX_VALUE_NAME_LENGTH 16383
 #define MAX_VALUE_DATA_LENGTH 2048
 
+extern int remote_add_provider;
+
 /* 
  * get registry root where keys are stored 
  * user keys are stored in user's hive
@@ -660,6 +662,12 @@ int process_add_smartcard_key(struct sshbuf* request, struct sshbuf* response, s
 		goto done;
 	}
 
+	if (con->nsession_ids != 0 && !remote_add_provider) {
+		verbose("failed PKCS#11 add of \"%.100s\": remote addition of "
+		    "providers is disabled", provider);
+		goto done;
+	}
+	
 	if (realpath(provider, canonical_provider) == NULL) {
 		error("failed PKCS#11 add of \"%.100s\": realpath: %s",
 			provider, strerror(errno));


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
- disable adding pkcs11 providers to ssh-agent if the ssh-agent is being forwarded
- add command-line argument (-Oallow-remote-pkcs11) to ssh-agent to override new behavior
## PR Context
- https://www.[openssh.com/txt/release-9.3p2](https://www.openssh.com/txt/release-9.3p2)
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
