### PR TITLE
Removed sha1-based MACs from default config

### DIFF
--- a/myproposal.h
+++ b/myproposal.h
@@ -68,12 +68,10 @@
 	"umac-128-etm@openssh.com," \
 	"hmac-sha2-256-etm@openssh.com," \
 	"hmac-sha2-512-etm@openssh.com," \
-	"hmac-sha1-etm@openssh.com," \
 	"umac-64@openssh.com," \
 	"umac-128@openssh.com," \
 	"hmac-sha2-256," \
-	"hmac-sha2-512," \
-	"hmac-sha1"
+	"hmac-sha2-512,"
 
 #define KEX_CLIENT_MAC KEX_SERVER_MAC
 

--- a/myproposal.h
+++ b/myproposal.h
@@ -63,6 +63,7 @@
 
 #define KEX_CLIENT_ENCRYPT KEX_SERVER_ENCRYPT
 
+#ifdef WINDOWS
 #define	KEX_SERVER_MAC \
 	"umac-64-etm@openssh.com," \
 	"umac-128-etm@openssh.com," \
@@ -72,6 +73,19 @@
 	"umac-128@openssh.com," \
 	"hmac-sha2-256," \
 	"hmac-sha2-512,"
+#else
+#define	KEX_SERVER_MAC \
+	"umac-64-etm@openssh.com," \
+	"umac-128-etm@openssh.com," \
+	"hmac-sha2-256-etm@openssh.com," \
+	"hmac-sha2-512-etm@openssh.com," \
+	"hmac-sha1-etm@openssh.com," \
+	"umac-64@openssh.com," \
+	"umac-128@openssh.com," \
+	"hmac-sha2-256," \
+	"hmac-sha2-512," \
+	"hmac-sha1"
+#endif
 
 #define KEX_CLIENT_MAC KEX_SERVER_MAC
 


### PR DESCRIPTION
# PR Summary

Removed MACs (message authentication code algorithms) that are using broken SHA-1 hash algorithm from the default config.
