### PR TITLE
Crank versions

### DIFF
--- a/contrib/win32/openssh/paths.targets
+++ b/contrib/win32/openssh/paths.targets
@@ -4,9 +4,9 @@
     <OpenSSH-Src-Path>$(SolutionDir)..\..\..\</OpenSSH-Src-Path>
     <OpenSSH-Bin-Path>$(SolutionDir)..\..\..\bin\</OpenSSH-Bin-Path>
     <OpenSSH-Lib-Path>$(SolutionDir)lib\</OpenSSH-Lib-Path>
-    <LibreSSLVersion>3.7.3.0</LibreSSLVersion>
+    <LibreSSLVersion>3.8.2.0</LibreSSLVersion>
     <ZLibVersion>1.3</ZLibVersion>
-    <fido2Version>1.13.0</fido2Version>
+    <fido2Version>1.14.0</fido2Version>
     <!--libcbor version is not used in the build; it is needed for pipeline compliance tasks-->  
     <libcborVersion>0.10.1</libcborVersion> 
     <LibreSSL-Path>$(SolutionDir)\LibreSSL\sdk\</LibreSSL-Path>

--- a/contrib/win32/openssh/version.rc
+++ b/contrib/win32/openssh/version.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 9,4,0,0
- PRODUCTVERSION 9,4,0,0
+ FILEVERSION 9,5,0,0
+ PRODUCTVERSION 9,5,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -67,9 +67,9 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "FileVersion", "9.4.0.0"
+            VALUE "FileVersion", "9.5.0.0"
             VALUE "ProductName", "OpenSSH for Windows"
-            VALUE "ProductVersion", "OpenSSH_9.4p1 for Windows"
+            VALUE "ProductVersion", "OpenSSH_9.5p1 for Windows"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- bump LibreSSL version to 3.8.2.0
- bump LibFido2 version to 1.14.0
- crank OpenSSH version to 9.5
