### PR TITLE
add double-quotes around service paths for SSHD and SSH-Agent

### DIFF
--- a/contrib/win32/openssh/install-sshd.ps1
+++ b/contrib/win32/openssh/install-sshd.ps1
@@ -129,12 +129,12 @@ if ($PSVersiontable.PSVersion -le '7.2.9') {
 }
 
 $agentDesc = "Agent to hold private keys used for public key authentication."
-New-Service -Name ssh-agent -DisplayName "OpenSSH Authentication Agent" -BinaryPathName "$sshagentpath" -Description $agentDesc -StartupType Manual | Out-Null
+New-Service -Name ssh-agent -DisplayName "OpenSSH Authentication Agent" -BinaryPathName "`"$sshagentpath`"" -Description $agentDesc -StartupType Manual | Out-Null
 sc.exe sdset ssh-agent "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RP;;;AU)"
 sc.exe privs ssh-agent SeAssignPrimaryTokenPrivilege/SeTcbPrivilege/SeBackupPrivilege/SeRestorePrivilege/SeImpersonatePrivilege
 
 $sshdDesc = "SSH protocol based service to provide secure encrypted communications between two untrusted hosts over an insecure network."
-New-Service -Name sshd -DisplayName "OpenSSH SSH Server" -BinaryPathName "$sshdpath" -Description $sshdDesc -StartupType Manual | Out-Null
+New-Service -Name sshd -DisplayName "OpenSSH SSH Server" -BinaryPathName "`"$sshdpath`"" -Description $sshdDesc -StartupType Manual | Out-Null
 sc.exe privs sshd SeAssignPrimaryTokenPrivilege/SeTcbPrivilege/SeBackupPrivilege/SeRestorePrivilege/SeImpersonatePrivilege
 
 Write-Host -ForegroundColor Green "sshd and ssh-agent services successfully installed"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
add double-quotes around service paths for SSHD and SSH-Agent when installing via the install script
<!-- Summarize your PR between here and the checklist. -->
