### PR TITLE
fix incorrect variable name in loginrec.c / utmpx_write_direct

### DIFF
--- a/loginrec.c
+++ b/loginrec.c
@@ -1033,7 +1033,7 @@ utmpx_perform_login(struct logininfo *li)
 		return (0);
 	}
 # else
-	if (!utmpx_write_direct(li, &ut)) {
+	if (!utmpx_write_direct(li, &utx)) {
 		logit("%s: utmp_write_direct() failed", __func__);
 		return (0);
 	}


### PR DESCRIPTION
# PR Summary

One of the code paths (not built on Windows) in loginrec.c utmpx_perform_login() calls utmpx_write_direct with the incorrect variable name "ut" instead of "utx", which can break the cross-platform build.

## PR Context

I maintain a cross-platform OpenSSH distribution derived from Win32-OpenSSH and this is something I have to patch on my side, so I'd rather have it fixed in Win32-OpenSSH. It's literally a one-letter pull request :)
