### PR TITLE
fix freezero duplicate symbol

### DIFF
--- a/contrib/win32/openssh/openbsd_compat.vcxproj
+++ b/contrib/win32/openssh/openbsd_compat.vcxproj
@@ -58,6 +58,7 @@
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\bsd-waitpid.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\daemon.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\dirname.c" />
+    <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\freezero.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\explicit_bzero.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\fake-rfc2553.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\fmt_scaled.c" />

--- a/contrib/win32/openssh/openbsd_compat.vcxproj.filters
+++ b/contrib/win32/openssh/openbsd_compat.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\dirname.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\freezero.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(OpenSSH-Src-Path)openbsd-compat\explicit_bzero.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -1512,15 +1512,6 @@ w32_ctime(const time_t* sourceTime)
 	return ctime_s(destTime, 26, sourceTime) == 0 ? destTime : NULL;
 }
 
-void
-freezero(void *ptr, size_t sz)
-{
-	if (ptr == NULL)
-		return;
-	explicit_bzero(ptr, sz);
-	free(ptr);
-}
-
 int 
 setenv(const char *name, const char *value, int rewrite)
 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix duplicate freezero symbol definition in contrib\win32\win32compat\misc.c which conflicts with freezero from libcrypto (LibreSSL). The same freezero function is now defined in openbsd-compat\freezero.c in between HAVE_FREEZERO ifdefs, but that file wasn't included into the builds, even if we include its companion file, explicit_bzero.c. Interesting observation: we do define HAVE_FREEZERO in the Win32-OpenSSH generated headers, so including the file contained the ifdef'ed freezero definition is the proper way to fix the issue, as we're using freezero from LibreSSL instead. However, if we were to make a build without freezero coming from LibreSSL, all we'd need to do is undefine HAVE_FREEZERO and it would still build properly.

## PR Context

The duplicate freezero symbol issue is somehow silenced in the Win32-OpenSSH Visual Studio project files, but it causes issues in my CMake build system on my Win32-OpenSSH fork. After investigation, the linker error is indeed correct: freezero is defined without ifdefs in contrib\win32\win32compat\misc.c yet the same function is defined in libcrypto from LibreSSL, using the exact same prebuilt library as the one used in the original build system. In other words: the issue isn't my CMake build system, but really a pre-existing issue in the original build system that is somehow silently ignored.

![image](https://github.com/PowerShell/openssh-portable/assets/295841/88a7a859-9775-40ed-9a0e-122495baf7b9)
