### PR TITLE
Use backslash for path displayed on Windows

### DIFF
--- a/pathnames.h
+++ b/pathnames.h
@@ -12,6 +12,14 @@
  * called by a name other than "ssh" or "Secure Shell".
  */
 
+#ifdef WINDOWS
+#define _PATH_SEPARATOR "\\"
+#define HOME_ENV_VAR "USERPROFILE"
+#else
+#define _PATH_SEPARATOR "/"
+#define HOME_ENV_VAR "HOME"
+#endif
+
 #define ETCDIR				"/etc"
 
 #ifndef SSHDIR
@@ -64,21 +72,21 @@
  * readable by anyone except the user him/herself, though this does not
  * contain anything particularly secret.
  */
-#define _PATH_SSH_USER_HOSTFILE		"~/" _PATH_SSH_USER_DIR "/known_hosts"
+#define _PATH_SSH_USER_HOSTFILE     "~" _PATH_SEPARATOR _PATH_SSH_USER_DIR _PATH_SEPARATOR "known_hosts"
 /* backward compat for protocol 2 */
-#define _PATH_SSH_USER_HOSTFILE2	"~/" _PATH_SSH_USER_DIR "/known_hosts2"
+#define _PATH_SSH_USER_HOSTFILE2    "~" _PATH_SEPARATOR _PATH_SSH_USER_DIR _PATH_SEPARATOR "/known_hosts2"
 
 /*
  * Name of the default file containing client-side authentication key. This
  * file should only be readable by the user him/herself.
  */
-#define _PATH_SSH_CLIENT_ID_DSA		_PATH_SSH_USER_DIR "/id_dsa"
-#define _PATH_SSH_CLIENT_ID_ECDSA	_PATH_SSH_USER_DIR "/id_ecdsa"
-#define _PATH_SSH_CLIENT_ID_RSA		_PATH_SSH_USER_DIR "/id_rsa"
-#define _PATH_SSH_CLIENT_ID_ED25519	_PATH_SSH_USER_DIR "/id_ed25519"
-#define _PATH_SSH_CLIENT_ID_XMSS	_PATH_SSH_USER_DIR "/id_xmss"
-#define _PATH_SSH_CLIENT_ID_ECDSA_SK	_PATH_SSH_USER_DIR "/id_ecdsa_sk"
-#define _PATH_SSH_CLIENT_ID_ED25519_SK	_PATH_SSH_USER_DIR "/id_ed25519_sk"
+#define _PATH_SSH_CLIENT_ID_DSA         _PATH_SSH_USER_DIR _PATH_SEPARATOR "id_dsa"
+#define _PATH_SSH_CLIENT_ID_ECDSA       _PATH_SSH_USER_DIR _PATH_SEPARATOR "id_ecdsa"
+#define _PATH_SSH_CLIENT_ID_RSA         _PATH_SSH_USER_DIR _PATH_SEPARATOR "id_rsa"
+#define _PATH_SSH_CLIENT_ID_ED25519     _PATH_SSH_USER_DIR _PATH_SEPARATOR "id_ed25519"
+#define _PATH_SSH_CLIENT_ID_XMSS        _PATH_SSH_USER_DIR _PATH_SEPARATOR "id_xmss"
+#define _PATH_SSH_CLIENT_ID_ECDSA_SK    _PATH_SSH_USER_DIR _PATH_SEPARATOR "id_ecdsa_sk"
+#define _PATH_SSH_CLIENT_ID_ED25519_SK  _PATH_SSH_USER_DIR _PATH_SEPARATOR "id_ed25519_sk"
 
 /*
  * Configuration file in user's home directory.  This file need not be
@@ -86,7 +94,7 @@
  * particularly secret.  If the user's home directory resides on an NFS
  * volume where root is mapped to nobody, this may need to be world-readable.
  */
-#define _PATH_SSH_USER_CONFFILE		_PATH_SSH_USER_DIR "/config"
+#define _PATH_SSH_USER_CONFFILE		_PATH_SSH_USER_DIR _PATH_SEPARATOR "config"
 
 /*
  * File containing a list of those rsa keys that permit logging in as this
@@ -96,10 +104,10 @@
  * may need to be world-readable.  (This file is read by the daemon which is
  * running as root.)
  */
-#define _PATH_SSH_USER_PERMITTED_KEYS	_PATH_SSH_USER_DIR "/authorized_keys"
+#define _PATH_SSH_USER_PERMITTED_KEYS	_PATH_SSH_USER_DIR _PATH_SEPARATOR "authorized_keys"
 
 /* backward compat for protocol v2 */
-#define _PATH_SSH_USER_PERMITTED_KEYS2	_PATH_SSH_USER_DIR "/authorized_keys2"
+#define _PATH_SSH_USER_PERMITTED_KEYS2	_PATH_SSH_USER_DIR _PATH_SEPARATOR "authorized_keys2"
 
 /*
  * Per-user and system-wide ssh "rc" files.  These files are executed with
@@ -107,7 +115,7 @@
  * passed "proto cookie" as arguments if X11 forwarding with spoofing is in
  * use.  xauth will be run if neither of these exists.
  */
-#define _PATH_SSH_USER_RC		_PATH_SSH_USER_DIR "/rc"
+#define _PATH_SSH_USER_RC		_PATH_SSH_USER_DIR _PATH_SEPARATOR "rc"
 #define _PATH_SSH_SYSTEM_RC		SSHDIR "/sshrc"
 
 /*

--- a/ssh-add.c
+++ b/ssh-add.c
@@ -1044,7 +1044,7 @@ main(int argc, char **argv)
 		}
 
 		for (i = 0; default_files[i]; i++) {
-			snprintf(buf, sizeof(buf), "%s/%s", pw->pw_dir,
+			snprintf(buf, sizeof(buf), "%s" _PATH_SEPARATOR "%s", pw->pw_dir,
 			    default_files[i]);
 			if (stat(buf, &st) == -1)
 				continue;

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -297,7 +297,7 @@ ask_filename(struct passwd *pw, const char *prompt)
 		}
 	}
 	snprintf(identity_file, sizeof(identity_file),
-	    "%s/%s", pw->pw_dir, name);
+	    "%s" _PATH_SEPARATOR "%s", pw->pw_dir, name);
 	printf("%s (%s): ", prompt, identity_file);
 	fflush(stdout);
 	if (fgets(buf, sizeof(buf), stdin) == NULL)

--- a/ssh.c
+++ b/ssh.c
@@ -572,7 +572,7 @@ process_config_files(const char *host_name, struct passwd *pw, int final_pass,
 			fatal("Can't open user config file %.100s: "
 			    "%.100s", config, strerror(errno));
 	} else {
-		r = snprintf(buf, sizeof buf, "%s/%s", pw->pw_dir,
+		r = snprintf(buf, sizeof buf, "%s" _PATH_SEPARATOR "%s", pw->pw_dir,
 		    _PATH_SSH_USER_CONFFILE);
 		if (r > 0 && (size_t)r < sizeof(buf))
 			(void)read_config_file(buf, pw, host, host_name,

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -72,6 +72,7 @@
 #include "ssherr.h"
 #include "authfd.h"
 #include "kex.h"
+#include "pathnames.h"
 
 struct sshkey *previous_host_key = NULL;
 
@@ -735,9 +736,11 @@ try_tilde_unexpand(const char *path)
 	char *home, *ret = NULL;
 	size_t l;
 
+#ifndef WINDOWS
 	if (*path != '/')
 		return xstrdup(path);
-	if ((home = getenv("HOME")) == NULL || (l = strlen(home)) == 0)
+#endif // !WINDOWS
+	if ((home = getenv(HOME_ENV_VAR)) == NULL || (l = strlen(home)) == 0)
 		return xstrdup(path);
 	if (strncmp(path, home, l) != 0)
 		return xstrdup(path);
@@ -745,12 +748,16 @@ try_tilde_unexpand(const char *path)
 	 * ensure we have matched on a path boundary: either the $HOME that
 	 * we just compared ends with a '/' or the next character of the path
 	 * must be a '/'.
+	 * 
+	 * *_PATH_SEPARATOR is used to obtain the char '/' from the path
+	 * separator string. When compiled for Windows, this will be '\\'
+	 * instead.
 	 */
-	if (home[l - 1] != '/' && path[l] != '/')
+	if (home[l - 1] != *_PATH_SEPARATOR && path[l] != *_PATH_SEPARATOR)
 		return xstrdup(path);
-	if (path[l] == '/')
+	if (path[l] == *_PATH_SEPARATOR)
 		l++;
-	xasprintf(&ret, "~/%s", path + l);
+	xasprintf(&ret, "~" _PATH_SEPARATOR "%s", path + l);
 	return ret;
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Currently, `ssh-keygen` outputs the following, where the mixed slashes cause confusion

```
$ ssh-keygen
Generating public/private ed25519 key pair.
Enter file in which to save the key (C:\Users\aanand/.ssh/id_ed25519):
$ ssh-keygen -y
Enter file in which the key is (C:\Users\aanand/.ssh/id_ed25519):
$ ssh-add
Enter passphrase for C:\Users\aanand/.ssh/id_ed25519:
```

This pull request uses a `_PATH_SEPARATOR` macro to separate path elements with `\` on Windows, and a `/` on other platforms. The new output is

```
$ ssh-keygen
Generating public/private ed25519 key pair.
Enter file in which to save the key (C:\Users\aanand\.ssh\id_ed25519):
$ ssh-keygen -y
Enter file in which the key is (C:\Users\aanand\.ssh\id_ed25519):
$ ssh-add
Enter passphrase for C:\Users\aanand\.ssh\id_ed25519:
```
to align with what a Windows user would expect to see.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
The confusion this issue causes is described in issues like [this one](https://github.com/PowerShell/Win32-OpenSSH/issues/469).

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
