### PR TITLE
fix how build script finds repo root

### DIFF
--- a/contrib/win32/openssh/OpenSSH-build.ps1
+++ b/contrib/win32/openssh/OpenSSH-build.ps1
@@ -1,7 +1,7 @@
 [cmdletbinding()]
 # PowerShell Script to clone, build and package PowerShell from specified fork and branch
 param (    
-    [string] $repolocation = "$pwd\openssh-portable",
+    [string] $repolocation = "$PSScriptRoot\..\..\..",
     [string] $destination = "$env:WORKSPACE",
     [ValidateSet('x86', 'x64', 'arm64', 'arm')]
     [String]$NativeHostArch = 'x64',        


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current build script relies on `$PWD` which means it matters from where you run the script.  Instead, it should be using `$PSScriptRoot` and navigate to the repo root location so the script can be run from any directory.
