### PR TITLE
remove HAVE_FREEZERO from preprocessor definitions

### DIFF
--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -1698,7 +1698,7 @@
 
 #define HAVE_BZERO 1
 #define PATH_MAX 32768
-#define S_IFIFO        0x1000  
+#define S_IFIFO        0x1000
 #define HAVE_EXPLICIT_BZERO
 #define HAVE_MBTOWC 1
 #define HAVE_LLABS 1
@@ -1713,7 +1713,7 @@
 #define __STDC__ 1
 
 #define umac128_new umac_new
-#define umac128_update umac_update 
+#define umac128_update umac_update
 #define umac_final umac128_final
 #define umac_delete umac128_delete
 
@@ -1727,7 +1727,6 @@
 #define _PATH_LS			"dir"
 #define _PATH_DEVNULL "NUL"
 #define FORK_NOT_SUPPORTED
-#define HAVE_FREEZERO
 #define FILESYSTEM_NO_BACKSLASH
 #define HAVE_LOCALTIME_R
 #define HAVE_DECL_MEMMEM 0


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- continuation of https://github.com/PowerShell/openssh-portable/pull/718 which removed `freezero` from `contrib\win32\win32compat\misc.c` and is causing SSHD to crash upon startup on x64 machines.
- need to remove `HAVE_FREEZERO` so that the method gets included from `openbsd-compat\freezero.c`

<!-- Summarize your PR between here and the checklist. -->

## PR Context
- helps downstream fork continue building without errors
- initial reasoning for including in `misc.c` was to not take a dependency on openbsd-compat (https://github.com/PowerShell/openssh-portable/pull/300#issuecomment-393243600) so if `openbsd-compat.lib` is eliminated in the future this will need revisiting
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
