### PR TITLE
revert Win32 change in timingsafe_bcmp

### DIFF
--- a/openbsd-compat/timingsafe_bcmp.c
+++ b/openbsd-compat/timingsafe_bcmp.c
@@ -27,10 +27,6 @@ timingsafe_bcmp(const void *b1, const void *b2, size_t n)
 	int ret = 0;
 
 	for (; n > 0; n--) {
-#ifdef WINDOWS
-		if (*p1 == '\r' && *(p1 + 1) == '\n' && *p2 == '\n')
-			p1++;
-#endif // WINDOWS
 		ret |= *p1++ ^ *p2++;
 	}
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- revert Win32 change in timingsafe_bcmp
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- initial code was added during port of bash tests to Windows
- current CI passes without it, and bash tests have modifications to remove carriage return from files when run on Windows
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
