### PR TITLE
remove getrnd() to sync with upstream

### DIFF
--- a/openbsd-compat/arc4random.c
+++ b/openbsd-compat/arc4random.c
@@ -107,58 +107,6 @@ _rs_init(u_char *buf, size_t n)
 	chacha_ivsetup(&rsx->rs_chacha, buf + KEYSZ);
 }
 
-#ifndef WITH_OPENSSL
-#ifdef WINDOWS
-#include <Wincrypt.h>
-static void
-getrnd(u_char *s, size_t len) {
-	HCRYPTPROV hProvider;
-	if (CryptAcquireContextW(&hProvider, 0, 0, PROV_RSA_FULL, 
-		CRYPT_VERIFYCONTEXT | CRYPT_SILENT) == FALSE ||
-	    CryptGenRandom(hProvider, len, s) == FALSE ||
-	    CryptReleaseContext(hProvider, 0) == FALSE)
-		fatal("%s Crypto error: %d", __func__, GetLastError());
-}
-
-#else /* !WINDOWS */
-# ifndef SSH_RANDOM_DEV
-#  define SSH_RANDOM_DEV "/dev/urandom"
-# endif /* SSH_RANDOM_DEV */
-static void
-getrnd(u_char *s, size_t len)
-{
-	int fd, save_errno;
-	ssize_t r;
-	size_t o = 0;
-
-#ifdef HAVE_GETRANDOM
-	if ((r = getrandom(s, len, 0)) > 0 && (size_t)r == len)
-		return;
-#endif /* HAVE_GETRANDOM */
-
-	if ((fd = open(SSH_RANDOM_DEV, O_RDONLY)) == -1) {
-		save_errno = errno;
-		/* Try egd/prngd before giving up. */
-		if (seed_from_prngd(s, len) == 0)
-			return;
-		fatal("Couldn't open %s: %s", SSH_RANDOM_DEV,
-		    strerror(save_errno));
-	}
-	while (o < len) {
-		r = read(fd, s + o, len - o);
-		if (r < 0) {
-			if (errno == EAGAIN || errno == EINTR ||
-			    errno == EWOULDBLOCK)
-				continue;
-			fatal("read %s: %s", SSH_RANDOM_DEV, strerror(errno));
-		}
-		o += r;
-	}
-	close(fd);
-}
-#endif /* !WINDOWS */
-#endif /* WITH_OPENSSL */
-
 static void
 _rs_stir(void)
 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- `getrnd()` was removed upstream in 9.1
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- https://github.com/openssh/openssh-portable/blob/V_9_0_P1/openbsd-compat/arc4random.c#L86
- https://github.com/openssh/openssh-portable/blob/V_9_1_P1/openbsd-compat/arc4random.c#L108
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
