### PR TITLE
Fix for Y2038 gettimeofday for Win32 builds

### DIFF
--- a/contrib/win32/win32compat/inc/sys/time.h
+++ b/contrib/win32/win32compat/inc/sys/time.h
@@ -1,7 +1,15 @@
+#pragma once
 #include <sys\utime.h>
 
 #define utimbuf _utimbuf
 #define utimes w32_utimes
+
+#define timeval w32_timeval
+struct timeval
+{
+	long long	tv_sec;
+	long        tv_usec;
+};
 
 int usleep(unsigned int);
 int gettimeofday(struct timeval *, void *);

--- a/contrib/win32/win32compat/inc/sys/time.h
+++ b/contrib/win32/win32compat/inc/sys/time.h
@@ -7,8 +7,8 @@
 #define timeval w32_timeval
 struct timeval
 {
-	long long	tv_sec;
-	long        tv_usec;
+    long long    tv_sec;
+    long         tv_usec;
 };
 
 int usleep(unsigned int);

--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -207,7 +207,7 @@ gettimeofday(struct timeval *tv, void *tz)
 	us = (timehelper.ns - EPOCH_DELTA) / 10;
 
 	/* Stuff result into the timeval */
-	tv->tv_sec = (long)(us / USEC_IN_SEC);
+	tv->tv_sec = (long long)(us / USEC_IN_SEC);
 	tv->tv_usec = (long)(us % USEC_IN_SEC);
 
 	return 0;


### PR DESCRIPTION

PR Summary
This is the second part of the fix for Y2038 issues, first part is on LibreSSL https://github.com/PowerShell/LibreSSL/pull/30 , we need to override the definition of timeval from winsock2.h.

PR Context
OpenSSH uses gettimeofday from LibreSSL, OpenSSH and LibreSSL has been using the definition of winsock2.h https://learn.microsoft.com/en-us/windows/win32/api/winsock2/ns-winsock2-timeval that is signed integer, this made LibreSSL and OpenSSH prone to the Y2038 problem.  As we modify the declaration of gettimeofday on LibreSSL we need to override the declaration of timeval in OpenSSH also to match the LibreSSL signature. 
Note that if we made this change the version of LibreSSL with the fix has to be released at the same time or signatures will not match. 
