### PR TITLE
fix group access check

### DIFF
--- a/contrib/win32/win32compat/win32_groupaccess.c
+++ b/contrib/win32/win32compat/win32_groupaccess.c
@@ -248,18 +248,17 @@ ga_init(const char *user, gid_t base)
 
 	if ((user_token = get_user_token(user_name, 0)) == NULL) {
 		/*
-		 * TODO - We need to fatal() all the times when we fail to generate the user token.
+		 * No fatal call here so experience when called by servconf parsing Match block
+		 * is consistent for an invalid user (does not find password, but is not fatal yet)
+		 * and a valid user without a token (ex: group policy forbidding login)
 		 */
-		if (get_custom_lsa_package()) {
-			error("%s, unable to resolve user %s", __func__, user_name);
-			return 0;
-		} else {
-			fatal("%s, unable to resolve user %s", __func__, user_name);
-		}
+		get_custom_lsa_package();
+		error("%s, unable to resolve user %s", __func__, user_name);
+		return 0;
 	}
 		
 	/* 
-	 * supposed to retun number of groups associated with user 
+	 * supposed to return number of groups associated with user 
 	 * since we do lazy group evaluation, returning 1 here
 	 */
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- small change to group access logic to return `0` instead of `fatal` when user token is not generated.

## PR Context
- `ga_init()` is utilized by servconf.c when parsing Match blocks and auth.c when checking Allow/Deny statements
- in case of servconf.c parsing a Match block, an invalid user results in no match and proceeds to prompting for a password before denying the login. previously, a valid user denied access to the computer from the network would reach the `fatal()` in `ga_init()` and never prompt for a password. This change makes the experience consistent across invalid/valid user names.