### PR TITLE
Set argv[argc] to NULL when calling main

### DIFF
--- a/contrib/win32/win32compat/wmain_common.c
+++ b/contrib/win32/win32compat/wmain_common.c
@@ -43,13 +43,12 @@ wmain(int argc, wchar_t **wargv) {
 	char** argv = NULL;
 	int i, r;
 	_set_invalid_parameter_handler(invalid_parameter_handler);
-	if (argc) {
-		if ((argv = malloc(argc * sizeof(char*))) == NULL)
+	if ((argv = malloc((argc + 1) * sizeof(char*))) == NULL)
+		fatal("out of memory");
+	for (i = 0; i < argc; i++)
+		if ((argv[i] = utf16_to_utf8(wargv[i])) == NULL)
 			fatal("out of memory");
-		for (i = 0; i < argc; i++)
-			if ((argv[i] = utf16_to_utf8(wargv[i])) == NULL)
-				fatal("out of memory");
-        }
+	argv[argc] = NULL;
 
 	if (getenv("SSH_AUTH_SOCK") == NULL)
 		_putenv("SSH_AUTH_SOCK=\\\\.\\pipe\\openssh-ssh-agent");

--- a/contrib/win32/win32compat/wmain_sshd-session.c
+++ b/contrib/win32/win32compat/wmain_sshd-session.c
@@ -50,15 +50,14 @@ int sshd_session_main(int argc, wchar_t **wargv) {
 	int i, r;
 	_set_invalid_parameter_handler(invalid_parameter_handler);
 
-	if (argc) {
-		if ((argv = malloc(argc * sizeof(char*))) == NULL) {
-			printf("out of memory");
-			exit(255);
-		}
-
-		for (i = 0; i < argc; i++)
-			argv[i] = utf16_to_utf8(wargv[i]);
+	if ((argv = malloc((argc + 1) * sizeof(char*))) == NULL) {
+		printf("out of memory");
+		exit(255);
 	}
+
+	for (i = 0; i < argc; i++)
+		argv[i] = utf16_to_utf8(wargv[i]);
+	argv[argc] = NULL;
 
 	w32posix_initialize();
 

--- a/contrib/win32/win32compat/wmain_sshd-session.c
+++ b/contrib/win32/win32compat/wmain_sshd-session.c
@@ -50,13 +50,12 @@ int sshd_session_main(int argc, wchar_t **wargv) {
 	int i, r;
 	_set_invalid_parameter_handler(invalid_parameter_handler);
 
-	if ((argv = malloc((argc + 1) * sizeof(char*))) == NULL) {
-		printf("out of memory");
-		exit(255);
-	}
+	if ((argv = malloc((argc + 1) * sizeof(char*))) == NULL)
+		fatal("out of memory");
 
 	for (i = 0; i < argc; i++)
-		argv[i] = utf16_to_utf8(wargv[i]);
+		if ((argv[i] = utf16_to_utf8(wargv[i])) == NULL)
+			fatal("out of memory");
 	argv[argc] = NULL;
 
 	w32posix_initialize();

--- a/contrib/win32/win32compat/wmain_sshd.c
+++ b/contrib/win32/win32compat/wmain_sshd.c
@@ -202,15 +202,14 @@ int sshd_main(int argc, wchar_t **wargv) {
 	int i, r;
 	_set_invalid_parameter_handler(invalid_parameter_handler);
 
-	if (argc) {
-		if ((argv = malloc(argc * sizeof(char*))) == NULL) {
-			printf("out of memory");
-			exit(255);
-		}
-
-		for (i = 0; i < argc; i++)
-			argv[i] = utf16_to_utf8(wargv[i]);
+	if ((argv = malloc((argc + 1) * sizeof(char*))) == NULL) {
+		printf("out of memory");
+		exit(255);
 	}
+
+	for (i = 0; i < argc; i++)
+		argv[i] = utf16_to_utf8(wargv[i]);
+	argv[argc] = NULL;
 
 	w32posix_initialize();
 

--- a/contrib/win32/win32compat/wmain_sshd.c
+++ b/contrib/win32/win32compat/wmain_sshd.c
@@ -202,13 +202,13 @@ int sshd_main(int argc, wchar_t **wargv) {
 	int i, r;
 	_set_invalid_parameter_handler(invalid_parameter_handler);
 
-	if ((argv = malloc((argc + 1) * sizeof(char*))) == NULL) {
-		printf("out of memory");
-		exit(255);
-	}
+	if ((argv = malloc((argc + 1) * sizeof(char*))) == NULL)
+		fatal("out of memory");
 
 	for (i = 0; i < argc; i++)
-		argv[i] = utf16_to_utf8(wargv[i]);
+		if ((argv[i] = utf16_to_utf8(wargv[i])) == NULL)
+			fatal("out of memory");
+
 	argv[argc] = NULL;
 
 	w32posix_initialize();


### PR DESCRIPTION
ISO C states that argv[argc] shall be a null pointer.

The OpenSSH codebase does not appear to rely on this currently, but better to be safe in case something changes.