### PR TITLE
remove sntrup761x25519-sha512 from supported kex list

### DIFF
--- a/myproposal.h
+++ b/myproposal.h
@@ -24,6 +24,19 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef WINDOWS
+ // these should be in the same order as upstream, without the ones we don't support
+#define KEX_SERVER_KEX	\
+	"curve25519-sha256," \
+	"curve25519-sha256@libssh.org," \
+	"ecdh-sha2-nistp256," \
+	"ecdh-sha2-nistp384," \
+	"ecdh-sha2-nistp521," \
+	"diffie-hellman-group-exchange-sha256," \
+	"diffie-hellman-group16-sha512," \
+	"diffie-hellman-group18-sha512," \
+	"diffie-hellman-group14-sha256"
+#else
 #define KEX_SERVER_KEX	\
 	"sntrup761x25519-sha512@openssh.com," \
 	"curve25519-sha256," \
@@ -35,6 +48,7 @@
 	"diffie-hellman-group16-sha512," \
 	"diffie-hellman-group18-sha512," \
 	"diffie-hellman-group14-sha256"
+#endif
 
 #define KEX_CLIENT_KEX KEX_SERVER_KEX
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- remove sntrup761x25519-sha512 from supported kex list, first added to list in v8.9, because it is not actually supported
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- fix https://github.com/PowerShell/Win32-OpenSSH/issues/2140
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
