### PR TITLE
make env vars optional for default allow list path

### DIFF
--- a/contrib/win32/win32compat/ssh-agent/keyagent-request.c
+++ b/contrib/win32/win32compat/ssh-agent/keyagent-request.c
@@ -679,9 +679,8 @@ int process_add_smartcard_key(struct sshbuf* request, struct sshbuf* response, s
 
 	to_lower_case(provider);
 	verbose("provider realpath: \"%.100s\"", provider);
-	to_lower_case(allowed_providers);
 	verbose("allowed provider paths: \"%.100s\"", allowed_providers);
-	if (match_pattern_list(provider, allowed_providers, 0) != 1) {
+	if (match_pattern_list(provider, allowed_providers, 1) != 1) {
 		verbose("refusing PKCS#11 add of \"%.100s\": "
 			"provider not allowed", provider);
 		goto done;

--- a/contrib/win32/win32compat/ssh-agent/keyagent-request.c
+++ b/contrib/win32/win32compat/ssh-agent/keyagent-request.c
@@ -677,9 +677,13 @@ int process_add_smartcard_key(struct sshbuf* request, struct sshbuf* response, s
 		goto done;
 	}
 
-	if (match_pattern_list(canonical_provider, allowed_providers, 0) != 1) {
+	to_lower_case(provider);
+	verbose("provider realpath: \"%.100s\"", provider);
+	to_lower_case(allowed_providers);
+	verbose("allowed provider paths: \"%.100s\"", allowed_providers);
+	if (match_pattern_list(provider, allowed_providers, 0) != 1) {
 		verbose("refusing PKCS#11 add of \"%.100s\": "
-			"provider not allowed", canonical_provider);
+			"provider not allowed", provider);
 		goto done;
 	}
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- remove `fatal()` calls if either `env:ProgramFiles` and `env:ProgramFiles(X86)` is not present (and allow list is not configured with `-P`), and instead fallback on initializing an empty allow list
- lowercase provider paths before `match_pattern_list()` to prevent false negatives
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- fix https://github.com/PowerShell/Win32-OpenSSH/issues/2286
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
