### PR TITLE
Add an environement variable to control stdio mode

### DIFF
--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -93,9 +93,7 @@ fd_table_initialize()
 
 	stdio_mode_env = getenv("OPENSSH_STDIO_MODE");
 	if (stdio_mode_env != NULL) {
-		if (strcmp(stdio_mode_env, "unknown") == 0)
-			stdio_mode = UNKNOWN_FD;
-		else if (strcmp(stdio_mode_env, "sock") == 0)
+		if (strcmp(stdio_mode_env, "sock") == 0)
 			stdio_mode = SOCK_FD;
 		else if (strcmp(stdio_mode_env, "nonsock") == 0)
 			stdio_mode = NONSOCK_FD;

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -88,6 +88,21 @@ fd_table_initialize()
 {
 	struct w32_io *pio;
 	HANDLE wh;
+	char *stdio_mode_env;
+	int stdio_mode = NONSOCK_SYNC_FD;
+
+	stdio_mode_env = getenv("OPENSSH_STDIO_MODE");
+	if (stdio_mode_env != NULL) {
+		if (strcmp(stdio_mode_env, "unknown") == 0)
+			stdio_mode = UNKNOWN_FD;
+		else if (strcmp(stdio_mode_env, "sock") == 0)
+			stdio_mode = SOCK_FD;
+		else if (strcmp(stdio_mode_env, "nonsock") == 0)
+			stdio_mode = NONSOCK_FD;
+		else if (strcmp(stdio_mode_env, "nonsock_sync") == 0)
+			stdio_mode = NONSOCK_SYNC_FD;
+	}
+
 	/* table entries representing std in, out and error*/
 	DWORD wh_index[] = { STD_INPUT_HANDLE , STD_OUTPUT_HANDLE , STD_ERROR_HANDLE };
 	int fd_num = 0;
@@ -104,7 +119,7 @@ fd_table_initialize()
 				return -1;
 			}
 			memset(pio, 0, sizeof(struct w32_io));
-			pio->type = NONSOCK_SYNC_FD;
+			pio->type = stdio_mode;
 			pio->handle = wh;
 			fd_table_set(pio, fd_num);
 		}


### PR DESCRIPTION
stdio descriptors (stdin, stdout and stderr) can be operated in various modes by win32compat code. The behavior is set very early in fd_table_initialize() by setting pio->type.

In https://github.com/PowerShell/Win32-OpenSSH/issues/1427 it was chosen to set pio->type to NONSOCK_SYNC_FD to resolve an I/O hang problem. Unfortunately this introduce problems for other ssh usage.

sshfs-wiun uses ssh and has at leas 6 open issues for the same problem introduced by this NONSOCK_SYNC_FD change: https://github.com/winfsp/sshfs-win/issues?q=is%3Aissue+cb+%3A87

The sshfs-win workaround it to use an older ssh.exe from cygwin, which is bundled with sshfs-win. This program is unable to use ssh-agent, which is quite frustrating. And if PATH is not set to use it, sshfs-win cannot work.

This change introduce an OPENSSH_STDIO_MODE environment variable that can be set to the following values: unknown, sock, nonsock, nonsock_sync. It cause pio->type to be set to UNKNOWN_FD, SOCK_FD, NONSOCK_FD, and NONSOCK_SYNC_FD respecitively. The default behavior when the variable is not set is unchanged (which means NONSOCK_SYNC_FD).

Setting OPENSSH_STDIO_MODE="nonsock" lets sshfs-win work again with openssh-portable ssh.exe. ssh-agent can be used, and this is good.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
