### PR TITLE
username logging fix

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -469,6 +469,7 @@ monitor_read_log(struct monitor *pmonitor)
 
 #ifdef WINDOWS
 	char* pname;
+	char* user;
 	u_int sftp_log_level, sftp_log_facility, sftp_log_stderr;
 	extern int log_stderr;
 	if ((r = sshbuf_get_cstring(logmsg, &pname, NULL)) != 0)
@@ -479,6 +480,8 @@ monitor_read_log(struct monitor *pmonitor)
 			(r = sshbuf_get_u32(logmsg, &sftp_log_facility)) != 0 ||
 			(r = sshbuf_get_u32(logmsg, &sftp_log_stderr)) != 0)
 			fatal_fr(r, "parse");
+		if ((r = sshbuf_get_cstring(logmsg, &user, NULL)) != 0)
+			user = NULL;
 	}
 
 	/*log it*/
@@ -487,7 +490,7 @@ monitor_read_log(struct monitor *pmonitor)
 	else {
 		if (strcmp(pname, "sftp-server") == 0) {
 			log_init(pname, sftp_log_level, sftp_log_facility, sftp_log_stderr);
-			sshlogdirect(level, forced, "%s", msg);
+			sshlogdirect(level, forced, "user: %s: %s", user, msg);
 			log_init("sshd", options.log_level, options.log_facility, log_stderr);
 		} else  
 			sshlogdirect(level, forced, "%s", msg);

--- a/monitor.c
+++ b/monitor.c
@@ -468,8 +468,7 @@ monitor_read_log(struct monitor *pmonitor)
 		fatal_f("invalid log level %u (corrupted message?)", level);
 
 #ifdef WINDOWS
-	char* pname;
-	char* user;
+	char* pname, * user = "(unknown user)";
 	u_int sftp_log_level, sftp_log_facility, sftp_log_stderr;
 	extern int log_stderr;
 	if ((r = sshbuf_get_cstring(logmsg, &pname, NULL)) != 0)
@@ -481,7 +480,7 @@ monitor_read_log(struct monitor *pmonitor)
 			(r = sshbuf_get_u32(logmsg, &sftp_log_stderr)) != 0)
 			fatal_fr(r, "parse");
 		if ((r = sshbuf_get_cstring(logmsg, &user, NULL)) != 0)
-			user = NULL;
+			user = "(unknown user)";
 	}
 
 	/*log it*/

--- a/monitor.c
+++ b/monitor.c
@@ -468,7 +468,7 @@ monitor_read_log(struct monitor *pmonitor)
 		fatal_f("invalid log level %u (corrupted message?)", level);
 
 #ifdef WINDOWS
-	char* pname, * user = "(unknown user)";
+	char* pname;
 	u_int sftp_log_level, sftp_log_facility, sftp_log_stderr;
 	extern int log_stderr;
 	if ((r = sshbuf_get_cstring(logmsg, &pname, NULL)) != 0)
@@ -479,20 +479,18 @@ monitor_read_log(struct monitor *pmonitor)
 			(r = sshbuf_get_u32(logmsg, &sftp_log_facility)) != 0 ||
 			(r = sshbuf_get_u32(logmsg, &sftp_log_stderr)) != 0)
 			fatal_fr(r, "parse");
-		if ((r = sshbuf_get_cstring(logmsg, &user, NULL)) != 0)
-			user = "(unknown user)";
 	}
 
 	/*log it*/
 	if (authctxt->authenticated == 0) 
-		sshlogdirect(level, forced, "%s [preauth]", msg);
+		sshlogdirect(level, forced, "user: %s: %s [preauth]", authctxt->user, msg);
 	else {
 		if (strcmp(pname, "sftp-server") == 0) {
 			log_init(pname, sftp_log_level, sftp_log_facility, sftp_log_stderr);
-			sshlogdirect(level, forced, "user: %s: %s", user, msg);
+			sshlogdirect(level, forced, "user: %s: %s", authctxt->user, msg);
 			log_init("sshd", options.log_level, options.log_facility, log_stderr);
 		} else  
-			sshlogdirect(level, forced, "%s", msg);
+			sshlogdirect(level, forced, "user: %s: %s", authctxt->user, msg);
 	}
 #else
 	/*log it*/

--- a/regress/pesterTests/FileBasedLogging.tests.ps1
+++ b/regress/pesterTests/FileBasedLogging.tests.ps1
@@ -200,7 +200,7 @@ exit"
 
             $sshdlog | Should Contain "Accepted publickey for $nonadminusername"
             $sshdlog | Should Contain "KEX done \[preauth\]"
-            $sshdlog | Should Contain "debug2: subsystem request for sftp by user $nonadminusername"
+            $sshdlog | Should Contain "debug2: user: $nonadminusername`: subsystem request for sftp by user $nonadminusername"
             $sftplog | Should Contain "session opened for local user $nonadminusername"
             $sftplog | Should Contain "debug3: user: $nonadminusername`: request 3: opendir"
             $sftplog | Should Contain "session closed for local user $nonadminusername"
@@ -216,9 +216,9 @@ exit"
   
             $sshdlog | Should Contain "Accepted publickey for $adminusername"
             $sshdlog | Should Contain "KEX done \[preauth\]"
-            $sshdlog | Should Contain "debug2: subsystem request for sftp by user $adminusername"
+            $sshdlog | Should Contain "debug2: user: $adminusername`: subsystem request for sftp by user $adminusername"
             $sftplog | Should Contain "session opened for local user $adminusername"
-            $sftplog | Should Contain "debug3: user: $nonadminusername`: request 3: opendir"
+            $sftplog | Should Contain "debug3: user: $adminusername`: request 3: opendir"
             $sftplog | Should Contain "session closed for local user $adminusername"
         }
     }

--- a/regress/pesterTests/FileBasedLogging.tests.ps1
+++ b/regress/pesterTests/FileBasedLogging.tests.ps1
@@ -202,7 +202,7 @@ exit"
             $sshdlog | Should Contain "KEX done \[preauth\]"
             $sshdlog | Should Contain "debug2: subsystem request for sftp by user $nonadminusername"
             $sftplog | Should Contain "session opened for local user $nonadminusername"
-            $sftplog | Should Contain "debug3: request 3: opendir"
+            $sftplog | Should Contain "debug3: user: $nonadminusername`: request 3: opendir"
             $sftplog | Should Contain "session closed for local user $nonadminusername"
         }
 
@@ -218,7 +218,7 @@ exit"
             $sshdlog | Should Contain "KEX done \[preauth\]"
             $sshdlog | Should Contain "debug2: subsystem request for sftp by user $adminusername"
             $sftplog | Should Contain "session opened for local user $adminusername"
-            $sftplog | Should Contain "debug3: request 3: opendir"
+            $sftplog | Should Contain "debug3: user: $nonadminusername`: request 3: opendir"
             $sftplog | Should Contain "session closed for local user $adminusername"
         }
     }

--- a/sftp-server.c
+++ b/sftp-server.c
@@ -1937,7 +1937,6 @@ log_handler(LogLevel level, int forced, const char* msg, void* ctx)
 		(r = sshbuf_put_u32(log_msg, log_facility_g)) != 0 ||
 		(r = sshbuf_put_u32(log_msg, log_stderr_g)) != 0)
 		fatal_fr(r, "assemble");
-
 	if ((len = sshbuf_len(log_msg)) < 4 || len > 0xffffffff)
 		fatal_f("bad length %zu", len);
 	POKE_U32(sshbuf_mutable_ptr(log_msg), len - 4);

--- a/sftp-server.c
+++ b/sftp-server.c
@@ -1935,8 +1935,7 @@ log_handler(LogLevel level, int forced, const char* msg, void* ctx)
 		(r = sshbuf_put_cstring(log_msg, __progname)) != 0 ||
 		(r = sshbuf_put_u32(log_msg, log_level)) != 0 ||
 		(r = sshbuf_put_u32(log_msg, log_facility_g)) != 0 ||
-		(r = sshbuf_put_u32(log_msg, log_stderr_g)) != 0 ||
-		(pw != NULL && (r = sshbuf_put_cstring(log_msg, pw->pw_name)) != 0))
+		(r = sshbuf_put_u32(log_msg, log_stderr_g)) != 0)
 		fatal_fr(r, "assemble");
 
 	if ((len = sshbuf_len(log_msg)) < 4 || len > 0xffffffff)

--- a/sftp-server.c
+++ b/sftp-server.c
@@ -1935,8 +1935,10 @@ log_handler(LogLevel level, int forced, const char* msg, void* ctx)
 		(r = sshbuf_put_cstring(log_msg, __progname)) != 0 ||
 		(r = sshbuf_put_u32(log_msg, log_level)) != 0 ||
 		(r = sshbuf_put_u32(log_msg, log_facility_g)) != 0 ||
-		(r = sshbuf_put_u32(log_msg, log_stderr_g)) != 0)
+		(r = sshbuf_put_u32(log_msg, log_stderr_g)) != 0 ||
+		(pw != NULL && (r = sshbuf_put_cstring(log_msg, pw->pw_name)) != 0))
 		fatal_fr(r, "assemble");
+
 	if ((len = sshbuf_len(log_msg)) < 4 || len > 0xffffffff)
 		fatal_f("bad length %zu", len);
 	POKE_U32(sshbuf_mutable_ptr(log_msg), len - 4);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- add `user: <username>` to logging messages from child processes (which may be redundant depending on message text, but didn't want to miss any, as this information was previously captured by the `User` field in Event Viewer).
- new behavior:
<img width="150" alt="after" src="https://github.com/user-attachments/assets/cc55329f-ab83-43b1-ae7e-631843ee740e">

- previous behavior:
<img width="101" alt="before" src="https://github.com/user-attachments/assets/e4a7a2fa-571e-4037-82ee-bea30045d927">
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- fix https://github.com/PowerShell/Win32-OpenSSH/issues/2295
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
