### PR TITLE
Workaround for hang in syncio_close

### DIFF
--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -293,7 +293,10 @@ syncio_close(struct w32_io* pio)
 			CancelSynchronousIo(pio->read_overlapped.hEvent);
 		}
 
-		WaitForSingleObject(pio->read_overlapped.hEvent, INFINITE);
+		// give the read thread some time to wind down, but don't block syncio_close
+		if (WAIT_TIMEOUT == WaitForSingleObject(pio->read_overlapped.hEvent, 1000)) {
+			debug4("read_overlapped thread timed out");
+		}
 	}
 
 	/* drain queued APCs */


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Hang in the cleanup frequently happens in Windows->Linux connections.
