### PR TITLE
Fix tilde expand for Windows paths with backslashes

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -1261,6 +1261,15 @@ tilde_expand(const char *filename, uid_t uid, char **retp)
 			path = NULL;			/* ~/ */
 		else
 			path = copy;			/* ~/path */
+#ifdef WINDOWS
+	// also need to account for backward slashes on Windows
+	} else if (*copy == '\\') {
+		copy += strspn(copy, "\\");
+		if (*copy == '\0')
+			path = NULL;			/* ~\ */
+		else
+			path = copy;			/* ~\path */
+#endif /* WINDOWS */
 	} else {
 		user = copy;
 		if ((path = strchr(copy, '/')) != NULL) {

--- a/regress/pesterTests/SSH.Tests.ps1
+++ b/regress/pesterTests/SSH.Tests.ps1
@@ -352,13 +352,13 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
         It "$tC.$tI - tilde expand for path with forward slash" {
             $o = ssh -v -i ~/test/key/path -E $logFile test_target echo 1234
             $o | Should Be "1234"
-            $logFile | Should -Not Contain "tilde_expand: No such user"
+            $logFile | Should Not Contain "tilde_expand: No such user"
         }
 
         It "$tC.$tI - tilde expand for path with backslash" {
             $o = ssh -v -i ~\test\key\path -E $logFile test_target echo 1234
             $o | Should Be "1234"
-            $logFile | Should -Not Contain "tilde_expand: No such user"
+            $logFile | Should Not Contain "tilde_expand: No such user"
         }
 
         It "$tC.$tI - auto populate known hosts" {

--- a/regress/pesterTests/SSH.Tests.ps1
+++ b/regress/pesterTests/SSH.Tests.ps1
@@ -5,9 +5,9 @@ Import-Module $PSScriptRoot\CommonUtils.psm1 -Force
 $tC = 1
 $tI = 0
 $suite = "sshclient"
-        
+
 Describe "E2E scenarios for ssh client" -Tags "CI" {
-    BeforeAll {        
+    BeforeAll {
         if($OpenSSHTestInfo -eq $null)
         {
             Throw "`$OpenSSHTestInfo is null. Please run Set-OpenSSHTestEnvironment to set test environments."
@@ -27,12 +27,12 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
         $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($ssouser, $rights, "ContainerInherit,Objectinherit", "None", "Allow")
         $acl.SetAccessRule($accessRule)
         Set-Acl -Path $testDir -AclObject $acl
-        #skip on ps 2 becase non-interactive cmd require a ENTER before it returns on ps2
+        #skip on ps 2 because non-interactive cmd require a ENTER before it returns on ps2
         $skip = $IsWindows -and ($PSVersionTable.PSVersion.Major -le 2)
 
         <#$testData = @(
             @{
-                Title = 'Simple logon no option';                
+                Title = 'Simple logon no option';
                 LogonStr = "$($server.localAdminUserName)@$($server.MachineName)"
                 Options = ""
             },
@@ -42,7 +42,7 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
                 Options = "-C -l $($server.localAdminUserName)"
             }
         )
-        
+
         $testData1 = @(
             @{
                 Title = "logon using -i -q option"
@@ -84,7 +84,7 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
                   [string] $default_shell_path,
                   [string] $default_shell_cmd_option_val = $null
             )
-            
+
             if (!(Test-Path $dfltShellRegPath)) {
                 New-Item -Path $dfltShellRegPath -Force | Out-Null
             }
@@ -99,12 +99,12 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
         $stderrFile=Join-Path $testDir "$tC.$tI.stderr.txt"
         $stdoutFile=Join-Path $testDir "$tC.$tI.stdout.txt"
         $logFile = Join-Path $testDir "$tC.$tI.log.txt"
-    }        
+    }
 
     AfterEach {$tI++;}
 
    Context "$tC - Basic Scenarios" {
-        
+
         BeforeAll {$tI=1}
         AfterAll{$tC++}
 
@@ -117,13 +117,13 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
             iex "cmd /c `"ssh -? 2> $stderrFile`""
             $stderrFile | Should Contain "usage: ssh"
         }
-        
+
         It "$tC.$tI - remote echo command" {
             iex "$sshDefaultCmd echo 1234" | Should Be "1234"
         }
 
     }
-    
+
     Context "$tC - exit code (exit-status.sh)" {
         BeforeAll {$tI=1}
         AfterAll{$tC++}
@@ -132,12 +132,12 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
             foreach ($i in (0,1,4,5,44)) {
                 ssh -p $port $ssouser@$server exit $i
                 $LASTEXITCODE | Should Be $i
-            }            
+            }
         }
     }
 
     Context "$tC - Redirection Scenarios" {
-        
+
         BeforeAll {$tI=1}
         AfterAll{$tC++}
 
@@ -192,7 +192,7 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
 
         }
     }
-    
+
     Context "$tC - configure powershell default shell Scenarios" {
         BeforeAll {
             $tI=1
@@ -205,13 +205,13 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
             $tC++
             Remove-ItemProperty -Path $dfltShellRegPath -Name $dfltShellRegKeyName -ErrorAction SilentlyContinue
             Remove-ItemProperty -Path $dfltShellRegPath -Name $dfltShellCmdOptionRegKeyName -ErrorAction SilentlyContinue
-        }        
+        }
 
         It "$tC.$tI - basic powershell" -skip:$skip {
             $o = ssh test_target Write-Output 1234
             $o | Should Be "1234"
         }
-        
+
         It "$tC.$tI - basic in powershell cmdlet" -skip:$skip {
             $o = ssh test_target "cd `$env:ProgramFiles;pwd"
             $LASTEXITCODE | Should Be 0
@@ -240,7 +240,7 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
         It "$tC.$tI - single quotes in powershell cmdlet" -skip:$skip {
             # actual command line ssh target echo '$env:computername'
             $o = ssh test_target "echo '`$env:computername'"
-            $LASTEXITCODE | Should Be 0            
+            $LASTEXITCODE | Should Be 0
             $o | Should Be `$env:computername
         }
     }
@@ -257,9 +257,9 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
             Remove-ItemProperty -Path $dfltShellRegPath -Name $dfltShellRegKeyName -ErrorAction SilentlyContinue
             Remove-ItemProperty -Path $dfltShellRegPath -Name $dfltShellCmdOptionRegKeyName -ErrorAction SilentlyContinue
         }
-        It "$tC.$tI - default shell as cmd" -skip:$skip {            
+        It "$tC.$tI - default shell as cmd" -skip:$skip {
             $o = ssh test_target where cmd
-            $o | Should Contain "cmd"            
+            $o | Should Contain "cmd"
         }
         It "$tC.$tI - cmd as default shell and double quotes in cmdline" {
             # actual command line ssh target echo "hello"
@@ -269,7 +269,7 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
         It "$tC.$tI - single quotes in powershell cmdlet" -skip:$skip {
             # actual command line ssh target echo '$env:computername'
             $o = ssh test_target "echo 'hello'"
-            $LASTEXITCODE | Should Be 0            
+            $LASTEXITCODE | Should Be 0
             $o | Should Be "'hello'"
         }
     }
@@ -290,15 +290,15 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
             $o | Should Be "`"hello`""
         }
     }
-    
-    Context "$tC - cmdline parameters" {        
+
+    Context "$tC - cmdline parameters" {
         BeforeAll {$tI=1}
         AfterAll{$tC++}
 
         It "$tC.$tI - verbose to file (-v -E)" {
             $o = ssh -v -E $logFile test_target echo 1234
             $o | Should Be "1234"
-            #TODO - checks below are very inefficient (time taking). 
+            #TODO - checks below are very inefficient (time taking).
             $logFile | Should Contain "OpenSSH_"
             $logFile | Should Contain "Exit Status 0"
         }
@@ -333,11 +333,11 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
             "    Port $port" | Add-Content $goodConfigFile
             "    User $ssouser" | Add-Content $goodConfigFile
             $o = ssh -F $goodConfigFile myhost echo 1234
-            $o | Should Be "1234"          
+            $o | Should Be "1234"
         }
 
         It "$tC.$tI - IP options - (-4) (-6)" {
-            # TODO - this test assumes target is localhost. 
+            # TODO - this test assumes target is localhost.
             # make it work independent of target
             #-4
             $o = ssh -4 -v -E $logFile test_target echo 1234
@@ -346,11 +346,23 @@ Describe "E2E scenarios for ssh client" -Tags "CI" {
             #-4
             $o = ssh -6 -v -E $logFile test_target echo 1234
             $o | Should Be "1234"
-            $logFile | Should Contain "[::1]"            
+            $logFile | Should Contain "[::1]"
+        }
+
+        It "$tC.$tI - tilde expand for path with forward slash" {
+            $o = ssh -v -i ~/test/key/path -E $logFile test_target echo 1234
+            $o | Should Be "1234"
+            $logFile | Should -Not Contain "tilde_expand: No such user"
+        }
+
+        It "$tC.$tI - tilde expand for path with backslash" {
+            $o = ssh -v -i ~\test\key\path -E $logFile test_target echo 1234
+            $o | Should Be "1234"
+            $logFile | Should -Not Contain "tilde_expand: No such user"
         }
 
         It "$tC.$tI - auto populate known hosts" {
-            
+
             $kh = Join-Path $testDir "$tC.$tI.known_hosts"
             $nul | Set-Content $kh
             # doing via cmd to intercept and drain stderr output


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- update `tilde_expand()` logic for Windows paths with backslashes
- add pester tests for basic `tilde_expand()` scenarios
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- fix https://github.com/PowerShell/Win32-OpenSSH/issues/2309
- upstream logic prior to v8.9 managed to cover paths with either forward or backslashes
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
