### PR TITLE
Update sshd_config to latest defaults

### DIFF
--- a/contrib/win32/openssh/sshd_config
+++ b/contrib/win32/openssh/sshd_config
@@ -12,7 +12,6 @@
 #ListenAddress ::
 
 #HostKey __PROGRAMDATA__/ssh/ssh_host_rsa_key
-#HostKey __PROGRAMDATA__/ssh/ssh_host_dsa_key
 #HostKey __PROGRAMDATA__/ssh/ssh_host_ecdsa_key
 #HostKey __PROGRAMDATA__/ssh/ssh_host_ed25519_key
 
@@ -61,12 +60,11 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #PrintMotd yes
 #PrintLastLog yes
 #TCPKeepAlive yes
-#UseLogin no
 #PermitUserEnvironment no
+#Compression delayed
 #ClientAliveInterval 0
 #ClientAliveCountMax 3
 #UseDNS no
-#PidFile /var/run/sshd.pid
 #MaxStartups 10:30:100
 #PermitTunnel no
 #ChrootDirectory none


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- update default sshd_config to match 9.8 default behavior (`Compression` and `HostKey`)
- remove deprecated (`UseLogin`) and unsupported on Windows (`PidFile`) directives 
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- https://github.com/PowerShell/openssh-portable/blob/latestw_all/sshd_config
- https://github.com/PowerShell/Win32-OpenSSH/wiki/sshd_config
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
