### PR TITLE
Increase stdin chunksize from 16 to 1024 chars

### DIFF
--- a/contrib/win32/win32compat/termio.c
+++ b/contrib/win32/win32compat/termio.c
@@ -48,8 +48,6 @@
 #include "tnnet.h"
 #include "misc_internal.h"
 
-#define TERM_IO_BUF_SIZE 2048
-
 extern int in_raw_mode;
 BOOL isFirstTime = TRUE;
 

--- a/contrib/win32/win32compat/tncon.h
+++ b/contrib/win32/win32compat/tncon.h
@@ -37,6 +37,9 @@
 
 #include "console.h"
 
+#define TERM_IO_BUF_SIZE_UTF16 1024
+#define TERM_IO_BUF_SIZE (3 * TERM_IO_BUF_SIZE_UTF16)
+
 #define UP_ARROW                    "\x1b[A"
 #define DOWN_ARROW                  "\x1b[B"
 #define RIGHT_ARROW                 "\x1b[C"


### PR DESCRIPTION
# PR Summary

This bumps the chunk size for `stdin` from 16 to 1024 chars.

## PR Context

It would be very unusual to `read()` from a file with a 16-byte buffer.
The same is true for `stdin`, but counter-intuitively it's actually
a lot "more true" for `stdin` than it would be for any file:
Since the `stdin` pipe is unbuffered and synchronous, the round-trip
overhead for reading from it is exorbitantly high. To put it into
perspective, on Windows the call overhead alone is roughly the same
as subsequentially reading in the order of 100K characters.

The increased buffer size has an immediately noticeable effect on
the interactive shells I've tested. Pasting content into a prompt now
appears immediately and atomically, while previously it would only
progressively arrive and get syntax highlighted repeatedly (= flicker).

Another nice benefit is that some shells have trouble determining
whether an escape character is a sequence inducer or a lone escape
character. Increasing the buffer size reduces the chance for hitting
this edge case from 1/16th (6%) to 1/1024th (0.1%) and makes it
very unlikely to occur at all for inputs <1024 characters.
This issue is what prompted me to make this modification.