### PR TITLE
add publish test results step to CI with pester test fix

### DIFF
--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -90,7 +90,7 @@ stages:
       vmImage: windows-latest
     displayName: Win32-OpenSSH On Windows
     variables:
-      systemDrive: '**'
+      testFilesDrivePath: '**'
     steps:
     - powershell: |
         $powerShellPath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'powershell'
@@ -167,13 +167,13 @@ stages:
       displayName: Run tests
 
     - pwsh: |
-        Write-Host "##vso[task.setvariable variable=systemDrive;]$env:SystemDrive"
+        Write-Host "##vso[task.setvariable variable=testFilesDrivePath;]$env:SystemDrive"
       displayName: Set variable
 
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'NUnit'
-        testResultsFiles: '$(systemDrive)/OpenSSHTests/*.xml'
+        testResultsFiles: '$(testFilesDrivePath)/OpenSSHTests/*.xml'
       condition: always()
 
     - pwsh: |

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -167,7 +167,7 @@ stages:
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'NUnit'
-        testResultsFiles: 'C:/OpenSSH/setupTestResults.xml'
+        testResultsFiles: 'C:/OpenSSHTests/setupTestResults.xml'
       condition: always()
 
     - pwsh: |

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -89,6 +89,8 @@ stages:
     pool:
       vmImage: windows-latest
     displayName: Win32-OpenSSH On Windows
+    variables:
+      systemDrive: '**'
     steps:
     - powershell: |
         $powerShellPath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'powershell'
@@ -164,10 +166,14 @@ stages:
         Invoke-OpenSSHTests -OpenSSHBinPath "$env:SystemDrive/OpenSSH"
       displayName: Run tests
 
+    - pwsh: |
+        Write-Host "##vso[task.setvariable variable=systemDrive;]$env:SystemDrive"
+      displayName: Set variable
+
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'NUnit'
-        testResultsFiles: 'C:/OpenSSHTests/setupTestResults.xml'
+        testResultsFiles: '$(systemDrive)/OpenSSHTests/*.xml'
       condition: always()
 
     - pwsh: |

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -164,6 +164,12 @@ stages:
         Invoke-OpenSSHTests -OpenSSHBinPath "$env:SystemDrive/OpenSSH"
       displayName: Run tests
 
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'NUnit'
+        testResultsFiles: '$env:SystemDrive/OpenSSH/setupTestResults.xml'
+      condition: always()
+
     - pwsh: |
         Import-Module -Name "$(Build.SourcesDirectory)/contrib/win32/openssh/AzDOBuildTools" -Force
         #

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -174,6 +174,7 @@ stages:
       inputs:
         testResultsFormat: 'NUnit'
         testResultsFiles: '$(testFilesDrivePath)/OpenSSHTests/*.xml'
+        failTaskOnFailedTests: true
       condition: always()
 
     - pwsh: |

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -167,7 +167,7 @@ stages:
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'NUnit'
-        testResultsFiles: '$env:SystemDrive/OpenSSH/setupTestResults.xml'
+        testResultsFiles: 'C:/OpenSSH/setupTestResults.xml'
       condition: always()
 
     - pwsh: |

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -535,9 +535,9 @@ Describe "Setup Tests" -Tags "Setup" {
             if (Test-Path -Path $logFolderPath) {
                 $logACL = Get-Acl $logFolderPath
             }
-            #if ((Get-Service sshd).Status -eq 'Running') {
-            #    net stop sshd
-            #}
+            if ((Get-Service sshd).Status -eq 'Running') {
+                net stop sshd
+            }
         }
         AfterAll {
             $tC++

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -1,4 +1,4 @@
-﻿If ($PSVersiontable.PSVersion.Major -le 2) {$PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path}
+If ($PSVersiontable.PSVersion.Major -le 2) {$PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path}
 Import-Module $PSScriptRoot\CommonUtils.psm1 -Force
 $suite = "Setup"
 $tC = 1
@@ -535,9 +535,9 @@ Describe "Setup Tests" -Tags "Setup" {
             if (Test-Path -Path $logFolderPath) {
                 $logACL = Get-Acl $logFolderPath
             }
-            if ((Get-Service sshd).Status -eq 'Running') {
-                net stop sshd
-            }
+            #if ((Get-Service sshd).Status -eq 'Running') {
+            #    net stop sshd
+            #}
         }
         AfterAll {
             $tC++

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -535,6 +535,9 @@ Describe "Setup Tests" -Tags "Setup" {
             if (Test-Path -Path $logFolderPath) {
                 $logACL = Get-Acl $logFolderPath
             }
+            if ((Get-Service sshd).Status -eq 'Running') {
+                net stop sshd
+            }
         }
         AfterAll {
             $tC++


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- in addition to uploading test results as a pipeline artifact, use `PublishTestResults` task to ensure that Pester test failures, like within `regress/pesterTests/Setup.Tests.ps1`, also fail the CI.
- fix test in `regress/pesterTests/Setup.Tests.ps1` that was silently failing previously due to the above.

