### PR TITLE
fix non-interactive session regression with sshd-session

### DIFF
--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1071,7 +1071,7 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 	si.hStdError = err;
 	si.dwFlags = STARTF_USESTDHANDLES;
 	
-	if (strstr(cmd, "sshd.exe")) {
+	if (strstr(cmd, "sshd-session.exe")) {
 		flags |= DETACHED_PROCESS;
 	}
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- with split of sshd into sshd listener and sshd session binaries, updating the win32 check for the process flag to `sshd-session` rather than `sshd`
- add corresponding test
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- fix https://github.com/PowerShell/Win32-OpenSSH/issues/2296
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
