### PR TITLE
Change the LOG_SYSLOG_VIS parameters to include VIS_NOSLASH

### DIFF
--- a/log.c
+++ b/log.c
@@ -70,7 +70,10 @@ static size_t nlog_verbose;
 extern char *__progname;
 
 #ifdef WINDOWS
-#define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL|VIS_LOG_UTF16)
+/* We need NOSLASH on windows to avoid double escaping slashes when having them
+ * in logs on purpose, such as when using the slog patches from hyperscale
+ */
+#define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL|VIS_LOG_UTF16|VIS_NOSLASH)
 #else
 #define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL)
 #endif


### PR DESCRIPTION
# PR Summary

Change the LOG_SYSLOG_VIS parameters to include VIS_NOSLASH so that it's possible to log slashes through to event logs - this allows, amoungst other things, pass through of structured logging when built with that patch.

Before:
```
debug3("logging a slash: \\ hi!")"
```

would output:
```
logging a slash: \\ hi!
```

instead of the correct:
```
logging a slash: \ hi!
```

## PR Context

This is important to us, since a logger we care about sends correctly escaped text through (specifically, the structured logging patch from hyperscale), causing serialisation issues.  (For our build, we've made current set of hyperscale patches work on windows - there might be a few more PR's to come around a couple of those integration points, but potentially if there's a desire for anything in there to hit windows, we could do PRs for that too)