### PR TITLE
Fix null pointer reference in sigaction.

### DIFF
--- a/contrib/win32/win32compat/signal.c
+++ b/contrib/win32/win32compat/signal.c
@@ -341,8 +341,12 @@ sigaction(int signum, const struct sigaction * act, struct sigaction * oldact)
 		return r;
 	}
 
-	if (act)
-		oldact->sa_handler = w32_signal(signum, act->sa_handler);
+	if (act) {
+		sighandler_t old_handler = w32_signal(signum, act->sa_handler);
+		if (oldact) {
+			oldact->sa_handler = old_handler;
+		}
+	}
 	else if (oldact)
 		oldact->sa_handler = sig_handlers[signum];
 


### PR DESCRIPTION
# PR Summary

Null pointer reference in `sigaction` emulation.

## PR Context

This is an obvious null pointer bug and was not surfaced yet since no call sites pass null `oldact` yet.
