### PR TITLE
fix integer underflow bug in ReadConsoleForTermEmulModern()

### DIFF
--- a/contrib/win32/win32compat/tncon.c
+++ b/contrib/win32/win32compat/tncon.c
@@ -183,11 +183,13 @@ ReadConsoleForTermEmulModern(HANDLE hInput, char *destin, int destinlen)
 		}
 	}
 
-	// Pop any lone lead surrogate from the input for later.
-	const wchar_t last_char = text[text_len - 1];
-	if (IS_HIGH_SURROGATE(last_char)) {
-		s_previous_lead = last_char;
-		text_len--;
+	if (text_len) {
+		// Pop any lone lead surrogate from the input for later.
+		const wchar_t last_char = text[text_len - 1];
+		if (IS_HIGH_SURROGATE(last_char)) {
+			s_previous_lead = last_char;
+			text_len--;
+		}
 	}
 
 	// ...and finally convert everything to UTF-8.


### PR DESCRIPTION
From https://github.com/directvt/vtm/issues/819#issuecomment-3358110811

> When a window resize event is received (terminal generates `WINDOW_BUFFER_SIZE_EVENT` event when switching between alternate/normal buffer mode), the variable `text_len=0` may accidentally decrease by one and become `text_len=-1`

potentially fixes PowerShell/Win32-OpenSSH#2275
