### PR TITLE
Fix duplicate output on console resize event

### DIFF
--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -225,17 +225,6 @@ ConEnterRawMode()
 	ScrollBottom = ConVisibleWindowHeight();
 	
 	in_raw_mode = 1;
-
-	/*
-	Consume and ignore the first WINDOW_BUFFER_SIZE_EVENT, as we've triggered it ourselves by updating the console settings above.
-	Not consuming this event can cause a race condition: the event can cause a write to the console to be printed twice as the
-	SIGWINCH interrupt makes the write operation think its failed, and causes it to try again.
-	*/
-	INPUT_RECORD peek_input;
-	int out_count = 0;
-	if (PeekConsoleInputW(GetConsoleInputHandle(), &peek_input, 1, &out_count) && peek_input.EventType == WINDOW_BUFFER_SIZE_EVENT) {
-		ReadConsoleInputW(GetConsoleInputHandle(), &peek_input, 1, &out_count);
-	}
 }
 
 /* Used to Uninitialize the Console */

--- a/contrib/win32/win32compat/signal.c
+++ b/contrib/win32/win32compat/signal.c
@@ -228,8 +228,8 @@ sw_process_pending_signals()
 		if (sigismember(&pending_tmp, exp[i])) {
 			if (sig_handlers[exp[i]] != W32_SIG_IGN) {
 				w32_raise(exp[i]);
-				/* dont error EINTR for SIG_ALRM, */
-				/* sftp client is not expecting it */
+				/* don't set errno=EINTR on SIGALRM, sftp client is not expecting it */
+				/* don't set errno=EINTR on SIGWINCH in order to avoid breaking the sequence of waiting for completion of IO operations. */
 				if (exp[i] != W32_SIGALRM && exp[i] != W32_SIGWINCH)
 					sig_int = TRUE;
 			} else if (exp[i] == W32_SIGCHLD) /*if SIGCHLD is SIG_IGN, reap zombies*/

--- a/contrib/win32/win32compat/signal.c
+++ b/contrib/win32/win32compat/signal.c
@@ -230,7 +230,7 @@ sw_process_pending_signals()
 				w32_raise(exp[i]);
 				/* dont error EINTR for SIG_ALRM, */
 				/* sftp client is not expecting it */
-				if (exp[i] != W32_SIGALRM)
+				if (exp[i] != W32_SIGALRM && exp[i] != W32_SIGWINCH)
 					sig_int = TRUE;
 			} else if (exp[i] == W32_SIGCHLD) /*if SIGCHLD is SIG_IGN, reap zombies*/
 				sw_cleanup_child_zombies();


### PR DESCRIPTION
# PR Summary

Fix the long-known issue of duplicate output.

- Fix false write operation rejection followed by retry on console resize event.
- Remove the workaround with ignoring the first console resize event. PowerShell/openssh-portable#426

## PR Context

When a console resize event is received, the event handler sets `errno` to `EINTR`, which falsely causes a concurrently pending write operation to be considered failed and retried. This results in duplicate console output, as well as duplicate application requests. This duplication can lead to an infinite loop, since a duplicate request generates another console resize event, which triggers another duplicate request. This can occur, for example, when terminals generate a resize event when an application requests a switch between alternate/normal buffer mode.

Fixes PowerShell/Win32-OpenSSH#2275 and most of related issues.

Related to:
- https://github.com/microsoft/terminal/issues/407
- https://github.com/microsoft/terminal/issues/7185
- https://github.com/microsoft/terminal/issues/8278
- https://github.com/microsoft/terminal/issues/8869
- https://github.com/microsoft/terminal/issues/9431
- https://github.com/microsoft/terminal/issues/11204
- https://github.com/microsoft/terminal/issues/15769
- https://github.com/microsoft/terminal/issues/18004
- https://github.com/microsoft/terminal/issues/18714
- https://github.com/microsoft/terminal/issues/19120
- https://github.com/microsoft/terminal/issues/19282
- https://github.com/microsoft/terminal/issues/19345
- https://github.com/microsoft/terminal/issues/19577
- https://github.com/microsoft/edit/issues/243
- https://github.com/microsoft/edit/issues/377
- https://github.com/microsoft/edit/issues/414
- https://github.com/microsoft/edit/issues/508
- https://github.com/microsoft/edit/issues/674
- https://github.com/tmux/tmux/issues/2844
- https://github.com/tmux/tmux/issues/3880
- https://github.com/tmux/tmux/issues/4535
- https://github.com/tmux/tmux/issues/4634
- https://github.com/tmux/tmux/issues/4642
- https://github.com/tmux-plugins/tpm/issues/272
- https://github.com/directvt/vtm/issues/819
- https://github.com/PowerShell/Win32-OpenSSH/issues/1253
- https://github.com/PowerShell/Win32-OpenSSH/issues/1256
- https://github.com/PowerShell/Win32-OpenSSH/issues/1376
- https://github.com/PowerShell/Win32-OpenSSH/issues/2275#issuecomment-3557420396
- https://github.com/PowerShell/openssh-portable/pull/426
- https://github.com/openai/codex/issues/4759
- https://github.com/openai/codex/issues/5584
- https://github.com/vim/vim/issues/19666

<!-- I can guess why this fix might be delayed in merging: https://github.com/PowerShell/openssh-portable/pull/674#issuecomment-2963703106 -->