### PR TITLE
Fix user environment block construction

### DIFF
--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -139,6 +139,8 @@ get_registry_key_value(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD* requ
 static void
 setup_session_user_vars(wchar_t* pw_dir_w)
 {
+	/* HOMEDRIVE and HOMEPATH are set by shell32!RegenerateUserEnvironment
+	   which is called on explorer.exe initialization in the user context. */
 	if (getenv("HOMEPATH") == NULL) {
 		if (pw_dir_w[0] && pw_dir_w[1] == L':') {
 			SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w + 2);

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -172,6 +172,10 @@ setup_session_user_vars(wchar_t* pw_dir_w)
 			free(user_path);
 		}
 	}
+	else if (hklm_path || hkcu_path) {
+		user_path = hklm_path ? hklm_path : hkcu_path;
+		SetEnvironmentVariableW(L"PATH", user_path);
+	}
 	if (hklm_path)
 		free(hklm_path);
 	if (hkcu_path)

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -121,6 +121,8 @@ get_registry_key_value(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD* requ
 		else {
 			error("Failed to get the registry key value.");
 		}
+		if (error_message)
+			free(error_message);
 		if (subkey)
 			free(subkey);
 		if (value)

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -99,161 +99,86 @@ get_registry_operation_error_message(const LONG error_code)
 	return message;
 }
 
-/* TODO  - built env var set and pass it along with CreateProcess */
-/* Set environment variables with values from the registry */
-/* Ensure that environment of new connections reflect the current state of the machine */
-static void
-setup_session_user_vars(wchar_t* profile_path)
+wchar_t*
+get_registry_key_value(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD* required)
 {
-	/* retrieve and set env variables. */
-	HKEY reg_key = 0;
-	wchar_t name[256];
-	wchar_t path[PATH_MAX + 1] = { 0, };
-	wchar_t *data = NULL, *data_expanded = NULL, *path_value = NULL, *to_apply;
-	DWORD type, name_chars = 256, data_chars = 0, data_expanded_chars = 0, required, i = 0;
-	LONG ret;
-	char *error_message;
+	wchar_t* data = NULL;
+	LSTATUS ret = RegGetValueW(hKey, lpSubKey, lpValue, RRF_RT_REG_SZ, NULL, NULL, required); /* RRF_RT_REG_SZ: automatically converts REG_EXPAND_SZ to REG_SZ. */
+	if (ret == ERROR_SUCCESS) {
+		data = malloc(*required);
+		if (data) {
+			ret = RegGetValueW(hKey, lpSubKey, lpValue, RRF_RT_REG_SZ, NULL, (LPBYTE)data, required);
+		}
+	}
+	if (ret != ERROR_SUCCESS) {
+		char* error_message = get_registry_operation_error_message(ret);
+		char* subkey = utf16_to_utf8(lpSubKey);
+		char* value = utf16_to_utf8(lpValue);
+		if (error_message && subkey && value) {
+			error("Failed to get the value for registry key %s\\%s. %s", subkey, value, error_message);
+			free(error_message);
+		}
+		else {
+			error("Failed to get the registry key value.");
+		}
+		if (subkey)
+			free(subkey);
+		if (value)
+			free(value);
+		if (data) { /* Reset data on errors. */
+			free(data);
+			data = NULL;
+		}
+	}
+	return data;
+}
 
-	/*These whitelisted environment variables should not be overwritten with the value from the registry*/
-	wchar_t* whitelist[] = { L"PROCESSOR_ARCHITECTURE", L"USERNAME" };
-
-	SetEnvironmentVariableW(L"USERPROFILE", profile_path);
-
-	if (profile_path[0] && profile_path[1] == L':') {
-		SetEnvironmentVariableW(L"HOMEPATH", profile_path + 2);
-		wchar_t wc = profile_path[2];
-		profile_path[2] = L'\0';
-		SetEnvironmentVariableW(L"HOMEDRIVE", profile_path);
-		profile_path[2] = wc;
+/* Build the user environment block. */
+/* Set the HOMEPATH variable (and optionally HOMEDRIVE) using the specified pw_dir_w profile path. */
+/* Set the PATH environment variable with values from the registry. */
+static void
+setup_session_user_vars(wchar_t* pw_dir_w)
+{
+	if (pw_dir_w[0] && pw_dir_w[1] == L':') {
+		SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w + 2);
+		wchar_t wc = pw_dir_w[2];
+		pw_dir_w[2] = L'\0';
+		SetEnvironmentVariableW(L"HOMEDRIVE", pw_dir_w);
+		pw_dir_w[2] = wc;
 	}
 	else
-		SetEnvironmentVariableW(L"HOMEPATH", profile_path);
+		SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w);
 
-	swprintf_s(path, _countof(path), L"%s\\AppData\\Local", profile_path);
-	SetEnvironmentVariableW(L"LOCALAPPDATA", path);
-	swprintf_s(path, _countof(path), L"%s\\AppData\\Roaming", profile_path);
-	SetEnvironmentVariableW(L"APPDATA", path);
-	
-	for (int j = 0; j < 2; j++)
-	{
-		/* First update the environment variables with the value from the System Environment, and then User. */
-		/* User variables overwrite the value of system variables with the same name (Except Path) */
-		if (j == 0)
-			ret = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", 0, KEY_QUERY_VALUE, &reg_key);
-		else
-			ret = RegOpenKeyExW(HKEY_CURRENT_USER, L"Environment", 0, KEY_QUERY_VALUE, &reg_key);
-
-		if (ret != ERROR_SUCCESS) {
-			error_message = get_registry_operation_error_message(ret);
-			if (error_message)
-			{
-				error("Unable to open Registry Key %s. %s", (j == 0 ? "HKEY_LOCAL_MACHINE" : "HKEY_CURRENT_USER"), error_message);
-				free(error_message);
-			}
-			else
-				error("Unable to open Registry Key %s. %s", (j == 0 ? "HKEY_LOCAL_MACHINE" : "HKEY_CURRENT_USER"));
-			continue;
+	/* PATH is a special case. The System Path value is preppended to the User Path value */
+	DWORD hklm_path_sz = 0;
+	DWORD hkcu_path_sz = 0;
+	wchar_t* user_path = NULL;
+	wchar_t* hklm_path = get_registry_key_value(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", L"PATH", &hklm_path_sz);
+	wchar_t* hkcu_path = get_registry_key_value(HKEY_CURRENT_USER, L"Environment", L"PATH", &hkcu_path_sz);
+	DWORD user_path_sz = hklm_path_sz + hkcu_path_sz;
+	if (hklm_path && hkcu_path) {
+		user_path = malloc(user_path_sz);
+		if (user_path) {
+			memcpy_s(user_path, user_path_sz, hklm_path, hklm_path_sz);
+			user_path[hklm_path_sz / sizeof(wchar_t) - 1] = L';'; /* Replace trailing null with ';'. */
+			memcpy_s(user_path + hklm_path_sz / sizeof(wchar_t), user_path_sz - hklm_path_sz, hkcu_path, hkcu_path_sz);
+			SetEnvironmentVariableW(L"PATH", user_path);
 		}
-		
-		while (1) {
-			to_apply = NULL;
-			required = data_chars * sizeof(wchar_t);
-			name_chars = 256;
-			ret = RegEnumValueW(reg_key, i++, name, &name_chars, 0, &type, (LPBYTE)data, &required);
-			if (ret == ERROR_NO_MORE_ITEMS)
-				break;
-			else if (ret == ERROR_MORE_DATA || required > data_chars * 2) {
-				if (data != NULL)
-					free(data);
-				data = xmalloc(required);
-				data_chars = required / 2;
-				i--;
-				continue;
-			}
-			else if (ret != ERROR_SUCCESS) {
-				error_message = get_registry_operation_error_message(ret);
-				if (error_message)
-				{
-					error("Failed to enumerate the value for registry key %s. %s", (j == 0 ? "HKEY_LOCAL_MACHINE" : "HKEY_CURRENT_USER"), error_message);
-					free(error_message);
-				}
-				else
-					error("Failed to enumerate the value for registry key %s", (j == 0 ? "HKEY_LOCAL_MACHINE" : "HKEY_CURRENT_USER"));
-				break;
-			}
-
-			if (type == REG_SZ)
-				to_apply = data;
-			else if (type == REG_EXPAND_SZ) {
-				required = ExpandEnvironmentStringsW(data, data_expanded, data_expanded_chars);
-				if (required > data_expanded_chars) {
-					if (data_expanded)
-						free(data_expanded);
-					data_expanded = xmalloc(required * 2);
-					data_expanded_chars = required;
-					ExpandEnvironmentStringsW(data, data_expanded, data_expanded_chars);
-				}
-				to_apply = data_expanded;
-			}
-
-			/* Ensure that variables in the whitelist are not being overwritten with the value from the registry */
-			for (int k = 0; k < ARRAYSIZE(whitelist); k++) {
-				if (_wcsicmp(name, whitelist[k]) == 0)
-				{
-					to_apply = NULL;
-				}
-			}
-
-			/* Path is a special case. The System Path value is preppended to the User Path value */
-			if (_wcsicmp(name, L"PATH") == 0 && j == 1) {
-				if ((required = GetEnvironmentVariableW(L"PATH", NULL, 0)) != 0) {
-					size_t user_path_size = wcslen(to_apply) + 1;
-					path_value = xmalloc((required + user_path_size) * 2);
-					GetEnvironmentVariableW(L"PATH", path_value, required);
-					path_value[required - 1] = L';';
-					GOTO_CLEANUP_ON_ERR(memcpy_s(path_value + required, user_path_size * 2, to_apply, user_path_size * 2));
-					to_apply = path_value;
-				}
-			}
-
-			if (to_apply)
-				SetEnvironmentVariableW(name, to_apply);
-				
-		}
-	cleanup:
-		if (reg_key)
-			RegCloseKey(reg_key);
-		if (data)
-			free(data);
-		if (data_expanded)
-			free(data_expanded);
-		if (path_value)
-			free(path_value);
-		i = 0;
-		data = NULL; 
-		data_expanded = NULL; 
-		path_value = NULL;
-		name_chars = 256; 
-		data_chars = 0; 
-		data_expanded_chars = 0;
-		reg_key = 0;
+		free(user_path);
 	}
+	if (hklm_path)
+		free(hklm_path);
+	if (hkcu_path)
+		free(hkcu_path);
 }
 
 static int
 setup_session_env(struct ssh *ssh, Session* s)
 {
 	int i = 0, ret = -1;
-	char *env_name = NULL, *env_value = NULL, *t = NULL, **env = NULL, *path_env_val = NULL;
+	char *env_name = NULL, *env_value = NULL, *t = NULL, **env = NULL;
 	char buf[1024] = { 0 };
 	wchar_t *env_name_w = NULL, *env_value_w = NULL, *pw_dir_w = NULL, *tmp = NULL, wbuf[1024] = { 0, };
-	char *c;
-
-	UTF8_TO_UTF16_WITH_CLEANUP(pw_dir_w, s->pw->pw_dir);
-	/* skip domain part (if present) while setting USERNAME */
-	c = strchr(s->pw->pw_name, '\\');
-	UTF8_TO_UTF16_WITH_CLEANUP(tmp, c ? c + 1 : s->pw->pw_name);
-	SetEnvironmentVariableW(L"USERNAME", tmp);
 
 	if (!s->is_subsystem) {
 		_snprintf(buf, ARRAYSIZE(buf), "%s@%s", s->pw->pw_name, getenv("COMPUTERNAME"));
@@ -268,6 +193,7 @@ setup_session_env(struct ssh *ssh, Session* s)
 		SetEnvironmentVariableW(L"PROMPT", wbuf);
 	}
 
+	UTF8_TO_UTF16_WITH_CLEANUP(pw_dir_w, s->pw->pw_dir);
 	setup_session_user_vars(pw_dir_w); /* setup user specific env variables */
 
 	env = do_setup_env_proxy(ssh, s, s->pw->pw_shell);

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -155,7 +155,7 @@ setup_session_user_vars(wchar_t* pw_dir_w)
 		}
 	}
 
-	/* PATH is a special case. The System Path value is preppended to the User Path value */
+	/* PATH is a special case. The System Path value is prepended to the User Path value */
 	DWORD hklm_path_sz = 0;
 	DWORD hkcu_path_sz = 0;
 	wchar_t* user_path = NULL;

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -116,7 +116,6 @@ get_registry_key_value(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD* requ
 		char* value = utf16_to_utf8(lpValue);
 		if (error_message && subkey && value) {
 			error("Failed to get the value for registry key %s\\%s. %s", subkey, value, error_message);
-			free(error_message);
 		}
 		else {
 			error("Failed to get the registry key value.");

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -169,8 +169,8 @@ setup_session_user_vars(wchar_t* pw_dir_w)
 			user_path[hklm_path_sz / sizeof(wchar_t) - 1] = L';'; /* Replace trailing null with ';'. */
 			memcpy_s(user_path + hklm_path_sz / sizeof(wchar_t), user_path_sz - hklm_path_sz, hkcu_path, hkcu_path_sz);
 			SetEnvironmentVariableW(L"PATH", user_path);
+			free(user_path);
 		}
-		free(user_path);
 	}
 	if (hklm_path)
 		free(hklm_path);

--- a/contrib/win32/win32compat/w32-doexec.c
+++ b/contrib/win32/win32compat/w32-doexec.c
@@ -134,20 +134,23 @@ get_registry_key_value(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD* requ
 }
 
 /* Build the user environment block. */
-/* Set the HOMEPATH variable (and optionally HOMEDRIVE) using the specified pw_dir_w profile path. */
+/* Set the HOMEPATH variable (and optionally HOMEDRIVE) using the specified pw_dir_w profile path if they are not assigned. */
 /* Set the PATH environment variable with values from the registry. */
 static void
 setup_session_user_vars(wchar_t* pw_dir_w)
 {
-	if (pw_dir_w[0] && pw_dir_w[1] == L':') {
-		SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w + 2);
-		wchar_t wc = pw_dir_w[2];
-		pw_dir_w[2] = L'\0';
-		SetEnvironmentVariableW(L"HOMEDRIVE", pw_dir_w);
-		pw_dir_w[2] = wc;
+	if (getenv("HOMEPATH") == NULL) {
+		if (pw_dir_w[0] && pw_dir_w[1] == L':') {
+			SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w + 2);
+			wchar_t wc = pw_dir_w[2];
+			pw_dir_w[2] = L'\0';
+			SetEnvironmentVariableW(L"HOMEDRIVE", pw_dir_w);
+			pw_dir_w[2] = wc;
+		}
+		else {
+			SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w);
+		}
 	}
-	else
-		SetEnvironmentVariableW(L"HOMEPATH", pw_dir_w);
 
 	/* PATH is a special case. The System Path value is preppended to the User Path value */
 	DWORD hklm_path_sz = 0;

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1147,7 +1147,7 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 			wchar_t* as_user_name = get_username_from_token(as_user);
 			if (as_user_name) {
 				if (wcsncmp(L"sshd", as_user_name, sizeof("sshd") - 1) != 0) { /* Ignore any names that begin with the service name `sshd`. */
-					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load the user environment block inheriting the current context. */
+					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load a user environment block inheriting the current context, passing in the session state. */
 				}
 				free(as_user_name);
 			}

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1056,21 +1056,6 @@ int fork()
 char * build_commandline_string(const char* cmd, char *const argv[], BOOLEAN prepend_module_path);
 
 wchar_t*
-get_username_from_environment()
-{
-	wchar_t* username = NULL;
-	DWORD name_length = GetEnvironmentVariableW(L"USERNAME", 0, 0); /* Figure out the length of the name. */
-	if (name_length) {
-		username = malloc(name_length * sizeof(wchar_t));
-		if (username) {
-			memset(username, 0, name_length);
-			GetEnvironmentVariableW(L"USERNAME", username, name_length);
-		}
-	}
-	return username;
-}
-
-wchar_t*
 get_username_from_token(HANDLE as_user)
 {
 	wchar_t* username = NULL;
@@ -1159,26 +1144,18 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 		if (as_user) {
 			debug3("spawning %ls as user", t);
 			LPVOID lpEnvironment = NULL;
-			BOOL foreign_user = FALSE; /* By default, we assume that the user environment block does not need to be loaded. */
 			wchar_t* as_user_name = get_username_from_token(as_user);
 			if (as_user_name) {
-				if (wcsncmp(L"sshd", as_user_name, sizeof("sshd") - 1) != 0) { /* Ignore any names starting with `sshd` (this is the service name). */
-					wchar_t* current_name = get_username_from_environment();
-					if (current_name) {
-						foreign_user = wcscmp(as_user_name, current_name) != 0;
-						free(current_name);
-					}
+				if (wcsncmp(L"sshd", as_user_name, sizeof("sshd") - 1) != 0) { /* Ignore any names that begin with the service name `sshd`. */
+					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load the user environment block inheriting the current context. */
 				}
 				free(as_user_name);
 			}
-			if (foreign_user) { /* Load user's environment block over current context if the current context is different. */
-				b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE);
-			}
-			if (lpEnvironment) { /* Apply user's environment block for the new process. */
+			if (lpEnvironment) { /* Pass the user environment block to the new process. */
 				b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags | CREATE_UNICODE_ENVIRONMENT, lpEnvironment, NULL, &si, &pi);
 				DestroyEnvironmentBlock(lpEnvironment);
 			}
-			else { /* Copy the current context's environment block to the new process. */
+			else { /* Pass the current context's environment block to the new process. */
 				b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
 			}
 		}

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1075,8 +1075,8 @@ get_username_from_token(HANDLE as_user)
 					if (domain_name) {
 						user_name = malloc(name_length * sizeof(wchar_t));
 						if (user_name) {
-							memset(user_name, 0, name_length);
-							memset(domain_name, 0, domain_length);
+							memset(user_name, 0, name_length * sizeof(wchar_t));
+							memset(domain_name, 0, domain_length * sizeof(wchar_t));
 							BOOL success = LookupAccountSidW(NULL, owner->User.Sid, user_name, &name_length, domain_name, &domain_length, &usage);
 							if (!success) /* Silently return an empty string if unsuccessful. */
 							{

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1148,10 +1148,7 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 			LPVOID lpEnvironment = NULL;
 			wchar_t* as_user_name = get_username_from_token(as_user);
 			if (as_user_name) {
-				if (wcsncmp(L"sshd", as_user_name, wcslen(L"sshd")) == 0) { /* Ignore any names that begin with the service name `sshd`. */
-					/* Do not create environment block for 'sshd' users. */
-				}
-				else {
+				if (wcsncmp(L"sshd", as_user_name, sizeof("sshd") - 1) != 0) { /* Ignore any names that begin with the service name `sshd`. */
 					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load a user environment block inheriting the current context, thereby passing session state. */
 				}
 				free(as_user_name);

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1147,7 +1147,7 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 			wchar_t* as_user_name = get_username_from_token(as_user);
 			if (as_user_name) {
 				if (wcsncmp(L"sshd", as_user_name, sizeof("sshd") - 1) != 0) { /* Ignore any names that begin with the service name `sshd`. */
-					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load a user environment block inheriting the current context, passing in the session state. */
+					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load a user environment block inheriting the current context, thereby passing session state. */
 				}
 				free(as_user_name);
 			}

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1058,7 +1058,7 @@ char * build_commandline_string(const char* cmd, char *const argv[], BOOLEAN pre
 wchar_t*
 get_username_from_token(HANDLE as_user)
 {
-	wchar_t* username = NULL;
+	wchar_t* user_name = NULL;
 	SID_NAME_USE usage;
 	DWORD count = 0;
 	GetTokenInformation(as_user, TokenUser, NULL, 0, &count);
@@ -1071,16 +1071,18 @@ get_username_from_token(HANDLE as_user)
 				DWORD domain_length = 0;
 				LookupAccountSidW(NULL, owner->User.Sid, NULL, &name_length, NULL, &domain_length, &usage); /* Figure out the length of the name. */
 				if (name_length) {
-					username = malloc(name_length * sizeof(wchar_t));
 					wchar_t* domain_name = malloc(domain_length * sizeof(wchar_t));
-					if (username) {
-						memset(username, 0, name_length);
-						memset(domain_name, 0, domain_length);
-						BOOL success = LookupAccountSidW(NULL, owner->User.Sid, username, &name_length, domain_name, &domain_length, &usage);
-						if (!success) /* Silently return an empty string if unsuccessful. */
-						{
-							free(username);
-							username = NULL;
+					if (domain_name) {
+						user_name = malloc(name_length * sizeof(wchar_t));
+						if (user_name) {
+							memset(user_name, 0, name_length);
+							memset(domain_name, 0, domain_length);
+							BOOL success = LookupAccountSidW(NULL, owner->User.Sid, user_name, &name_length, domain_name, &domain_length, &usage);
+							if (!success) /* Silently return an empty string if unsuccessful. */
+							{
+								free(user_name);
+								user_name = NULL;
+							}
 						}
 						free(domain_name);
 					}
@@ -1089,7 +1091,7 @@ get_username_from_token(HANDLE as_user)
 			free(buffer);
 		}
 	}
-	return username;
+	return user_name;
 }
 
 /*

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1148,7 +1148,7 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 			LPVOID lpEnvironment = NULL;
 			wchar_t* as_user_name = get_username_from_token(as_user);
 			if (as_user_name) {
-				if (wcsncmp(L"sshd", as_user_name, sizeof("sshd") - 1) != 0) { /* Ignore any names that begin with the service name `sshd`. */
+				if (wcsncmp(L"sshd", as_user_name, wcslen(L"sshd")) != 0) { /* Ignore any names that begin with the service name `sshd`. */
 					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load a user environment block inheriting the current context, thereby passing session state. */
 				}
 				free(as_user_name);

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -53,6 +53,7 @@
 #include <sys\utime.h>
 #include "misc_internal.h"
 #include "debug.h"
+#include "userenv.h"
 
 /* internal table that stores the fd to w32_io mapping*/
 struct w32fd_table {
@@ -1054,6 +1055,58 @@ int fork()
 }
 char * build_commandline_string(const char* cmd, char *const argv[], BOOLEAN prepend_module_path);
 
+wchar_t*
+get_username_from_environment()
+{
+	wchar_t* username = NULL;
+	DWORD name_length = GetEnvironmentVariableW(L"USERNAME", 0, 0); /* Figure out the length of the name. */
+	if (name_length) {
+		username = malloc(name_length * sizeof(wchar_t));
+		if (username) {
+			memset(username, 0, name_length);
+			GetEnvironmentVariableW(L"USERNAME", username, name_length);
+		}
+	}
+	return username;
+}
+
+wchar_t*
+get_username_from_token(HANDLE as_user)
+{
+	wchar_t* username = NULL;
+	SID_NAME_USE usage;
+	DWORD count = 0;
+	GetTokenInformation(as_user, TokenUser, NULL, 0, &count);
+	if (count) {
+		void* buffer = malloc(count);
+		if (buffer) {
+			if (GetTokenInformation(as_user, TokenUser, buffer, count, &count)) {
+				TOKEN_USER* owner = (TOKEN_USER*)buffer;
+				DWORD name_length = 0;
+				DWORD domain_length = 0;
+				LookupAccountSidW(NULL, owner->User.Sid, NULL, &name_length, NULL, &domain_length, &usage); /* Figure out the length of the name. */
+				if (name_length) {
+					username = malloc(name_length * sizeof(wchar_t));
+					wchar_t* domain_name = malloc(domain_length * sizeof(wchar_t));
+					if (username) {
+						memset(username, 0, name_length);
+						memset(domain_name, 0, domain_length);
+						BOOL success = LookupAccountSidW(NULL, owner->User.Sid, username, &name_length, domain_name, &domain_length, &usage);
+						if (!success) /* Silently return an empty string if unsuccessful. */
+						{
+							free(username);
+							username = NULL;
+						}
+						free(domain_name);
+					}
+				}
+			}
+			free(buffer);
+		}
+	}
+	return username;
+}
+
 /*
 * spawn a child process
 * - specified by cmd with agruments argv
@@ -1105,7 +1158,29 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 	do {
 		if (as_user) {
 			debug3("spawning %ls as user", t);
-			b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
+			LPVOID lpEnvironment = NULL;
+			BOOL foreign_user = FALSE; /* By default, we assume that the user environment block does not need to be loaded. */
+			wchar_t* as_user_name = get_username_from_token(as_user);
+			if (as_user_name) {
+				if (wcsncmp(L"sshd", as_user_name, sizeof("sshd") - 1) != 0) { /* Ignore any names starting with `sshd` (this is the service name). */
+					wchar_t* current_name = get_username_from_environment();
+					if (current_name) {
+						foreign_user = wcscmp(as_user_name, current_name) != 0;
+						free(current_name);
+					}
+				}
+				free(as_user_name);
+			}
+			if (foreign_user) { /* Load user's environment block over current context if the current context is different. */
+				b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE);
+			}
+			if (lpEnvironment) { /* Apply user's environment block for the new process. */
+				b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags | CREATE_UNICODE_ENVIRONMENT, lpEnvironment, NULL, &si, &pi);
+				DestroyEnvironmentBlock(lpEnvironment);
+			}
+			else { /* Copy the current context's environment block to the new process. */
+				b = CreateProcessAsUserW(as_user, NULL, t, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi);
+			}
 		}
 		else {
 			debug3("spawning %ls as subprocess", t);

--- a/contrib/win32/win32compat/w32fd.c
+++ b/contrib/win32/win32compat/w32fd.c
@@ -1148,7 +1148,10 @@ spawn_child_internal(const char* cmd, char *const argv[], HANDLE in, HANDLE out,
 			LPVOID lpEnvironment = NULL;
 			wchar_t* as_user_name = get_username_from_token(as_user);
 			if (as_user_name) {
-				if (wcsncmp(L"sshd", as_user_name, wcslen(L"sshd")) != 0) { /* Ignore any names that begin with the service name `sshd`. */
+				if (wcsncmp(L"sshd", as_user_name, wcslen(L"sshd")) == 0) { /* Ignore any names that begin with the service name `sshd`. */
+					/* Do not create environment block for 'sshd' users. */
+				}
+				else {
 					b = CreateEnvironmentBlock(&lpEnvironment, as_user, TRUE); /* Load a user environment block inheriting the current context, thereby passing session state. */
 				}
 				free(as_user_name);


### PR DESCRIPTION
# PR Summary

Fix construction of user environment block when user connects.

## PR Context

Currently, when a user connects, the environment block from the LocalSystem context (in which sshd.exe
is running) is used to create the user session environment.

The fix ensures that the user environment block is loaded for users with names without the `sshd` prefix.

Fixes PowerShell/Win32-OpenSSH#2407