### PR TITLE
add back explicit termination of preauth child process

### DIFF
--- a/regress/pesterTests/SSHD.Tests.ps1
+++ b/regress/pesterTests/SSHD.Tests.ps1
@@ -55,8 +55,8 @@ Describe "E2E scenarios for sshd" -Tags "CI" {
 
             # with a connection, there should be two additional session processes
             $sshdPidsCountWithConn | Should Be (2 + $sshdPidCountBefore)
-            # after LoginGraceTime expires, one of the session processes should exit
-            $sshdPidsCountAfter | Should Be (1 + $sshdPidCountBefore)
+            # after LoginGraceTime expires, both session processes should exit
+            $sshdPidsCountAfter | Should Be $sshdPidCountBefore
         }
 
         It "sshd pre-auth process is spawned under runtime generated virtual account" {

--- a/sshd-session.c
+++ b/sshd-session.c
@@ -335,7 +335,7 @@ pack_config(struct sshbuf* conf)
 static void
 send_config_state(int fd, struct sshbuf* conf)
 {
-	/* copied from send_rexec_state() in sshd.c 
+	/* copied from send_rexec_state() in sshd.c
 	   On Windows, uses pack_hostkeys_for_child() and pack_config() */
 	struct sshbuf* keys;
 	u_int mlen;
@@ -542,7 +542,15 @@ privsep_child_cmdline()
 static void
 grace_alarm_handler(int sig)
 {
-#ifndef WINDOWS
+#ifdef WINDOWS
+	/*
+	 * continue to use explicit kill on the child process ID
+	 * Windows does not currently support authorized keys
+	 * command helpers, so this is sufficient
+	 */
+	if (pmonitor != NULL && pmonitor->m_pid > 0)
+		kill(pmonitor->m_pid, SIGALRM);
+#else
 	/*
 	 * Try to kill any processes that we have spawned, E.g. authorized
 	 * keys command helpers or privsep children.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- add back code that was removed starting in V8.9 which prevented the pre-auth child process from being terminated when LoginGraceTime expired, potentially leading to a build-up of orphaned child processes until the corresponding client disconnected
- update LoginGraceTime pester test
 
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- https://github.com/PowerShell/Win32-OpenSSH/discussions/2409
- V8.6: https://github.com/PowerShell/openssh-portable/blob/v8.6.0.0/sshd.c#L366-L385
- V8.9: https://github.com/PowerShell/openssh-portable/blob/v8.9.0.0/sshd.c#L382-L397
- related upstream commit: https://github.com/openssh/openssh-portable/commit/4e62c13ab419b4b224c8bc6a761e91fcf048012d
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
