### PR TITLE
Fix Add-MachinePath to preserve registry value type and unexpanded variables

### DIFF
--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -841,8 +841,8 @@ Function Add-MachinePath {
         $machinePath = (Get-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
         if (-not ($machinePath.ToLower().Contains("$FilePath;".ToLower()) -or $machinePath.ToLower().Contains("$FilePath\;".ToLower())))
         {
-            $newPath = $FilePath + ’;’ + $machinePath 
-            Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH –Value $newPath
+            $newPath = $FilePath + ';' + $machinePath 
+            Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
             if ((Get-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path -eq $newPath) {
                 Write-Host "Updated Machine PATH to include OpenSSH directory, restart/re-login required to take effect globally" -ForegroundColor Yellow
             }

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -829,7 +829,7 @@ function Enable-Privilege {
     $type[0]::EnablePrivilege($Privilege, $Disable)
 }
 
-Function Add-MachinePath {
+function Add-MachinePath {
     [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="High")]
     param
     (
@@ -843,12 +843,12 @@ Function Add-MachinePath {
         $pathType  = $regKey.GetValueKind('PATH')
 
         # Normalize for comparison only (expand variables and trim trailing backslash)
-        $normalizedFilePath = $FilePath.TrimEnd('\')
-        $normalizedEntries  = $pathValue -split ';' | ForEach-Object {
-            [Environment]::ExpandEnvironmentVariables($_).TrimEnd('\')
-        }
+        $normalizedFilePath = [Environment]::ExpandEnvironmentVariables($FilePath).TrimEnd('\')
+        $normalizedEntries = $pathValue -split ';' |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            ForEach-Object { [Environment]::ExpandEnvironmentVariables($_.Trim()).TrimEnd('\') }
 
-        if ($normalizedEntries -notcontains $normalizedFilePath) {
+        if ($normalizedEntries.Where({ $_ -ieq $normalizedFilePath }, 'First').Count -eq 0) {
             $newPath = $FilePath + ';' + $pathValue
 
             $message     = "Need to add the path to the Machine PATH environment variable."

--- a/contrib/win32/openssh/OpenSSHUtils.psm1
+++ b/contrib/win32/openssh/OpenSSHUtils.psm1
@@ -838,13 +838,30 @@ Function Add-MachinePath {
     )
 
     if (Test-Path $FilePath) {
-        $machinePath = (Get-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-        if (-not ($machinePath.ToLower().Contains("$FilePath;".ToLower()) -or $machinePath.ToLower().Contains("$FilePath\;".ToLower())))
-        {
-            $newPath = $FilePath + ';' + $machinePath 
-            Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
-            if ((Get-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path -eq $newPath) {
-                Write-Host "Updated Machine PATH to include OpenSSH directory, restart/re-login required to take effect globally" -ForegroundColor Yellow
+        $regKey    = Get-Item -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment'
+        $pathValue = $regKey.GetValue('PATH', '', 'DoNotExpandEnvironmentNames')
+        $pathType  = $regKey.GetValueKind('PATH')
+
+        # Normalize for comparison only (expand variables and trim trailing backslash)
+        $normalizedFilePath = $FilePath.TrimEnd('\')
+        $normalizedEntries  = $pathValue -split ';' | ForEach-Object {
+            [Environment]::ExpandEnvironmentVariables($_).TrimEnd('\')
+        }
+
+        if ($normalizedEntries -notcontains $normalizedFilePath) {
+            $newPath = $FilePath + ';' + $pathValue
+
+            $message     = "Need to add the path to the Machine PATH environment variable."
+            $prompt      = "Shall I add '$FilePath' to Machine PATH?"
+            $description = "Add '$FilePath' to Machine PATH."
+
+            if ($PSCmdlet.ShouldProcess($description, $prompt, $message)) {
+                Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath -Type $pathType
+
+                $verifyValue = (Get-Item -Path 'HKLM:\System\CurrentControlSet\Control\Session Manager\Environment').GetValue('PATH', '', 'DoNotExpandEnvironmentNames')
+                if ($verifyValue -eq $newPath) {
+                    Write-Host "Updated Machine PATH to include OpenSSH directory, restart/re-login required to take effect globally" -ForegroundColor Yellow
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
# PR Summary
Fix `Add-MachinePath` function to preserve PATH registry value type and unexpanded environment variables when adding new paths.

<!-- Summarize your PR between here and the checklist. -->
## PR Context
Existing implementation has several issues:
- Automatically expands environment variables (e.g., `%SystemRoot%` becomes `C:\Windows`)
- Does not preserve the existing registry property value type (`REG_SZ` vs `REG_EXPAND_SZ`)
- Fails to detect duplicate paths with different formats (trailing backslash, expanded vs unexpanded)

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
## Changes
- Use `GetValue()` with `DoNotExpandEnvironmentNames` to preserve unexpanded variables
- Normalize paths for comparison only (expansion + backslash trimming) without modifying original entries
- Implement proper `ShouldProcess` for `-WhatIf`/`-Confirm` support
- Fix non-ASCII character in `Set-ItemProperty` parameter (see first commit)