### PR TITLE
update CI to use window-latest image and fix local caching

### DIFF
--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -10,6 +10,9 @@ pr:
     include:
     - latestw_all
 
+variables:
+  vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
+
 stages:
 - stage: BuildDependencies
   displayName: Build Dependencies
@@ -23,7 +26,7 @@ stages:
       parameters:
         triplet: x64-custom
         artifactSuffix: x64
-        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
+        vcpkgCacheDir: '$(vcpkgCacheDir)'
 
   - job: InstallDeps_x86
     displayName: Install vcpkg Dependencies (x86)
@@ -34,7 +37,7 @@ stages:
       parameters:
         triplet: x86-custom
         artifactSuffix: x86
-        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
+        vcpkgCacheDir: '$(vcpkgCacheDir)'
 
 - stage: Build
   displayName: Build Win32-OpenSSH
@@ -52,8 +55,7 @@ stages:
         artifactSuffix: x64
         dependenciesArtifactName: vcpkg-dependencies-x64
         includeConfig: true
-        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
-
+        vcpkgCacheDir: '$(vcpkgCacheDir)'
 
   - job: BuildPkg_x86
     displayName: Build Package (x86)
@@ -66,7 +68,7 @@ stages:
         buildOutputDir: Win32
         artifactSuffix: x86
         dependenciesArtifactName: vcpkg-dependencies-x86
-        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
+        vcpkgCacheDir: '$(vcpkgCacheDir)'
 
 - stage: Test
   displayName: Test Win32-OpenSSH

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -17,9 +17,7 @@ stages:
   - job: InstallDeps_x64
     displayName: Install vcpkg Dependencies (x64)
     pool:
-      name: PS-PowerShell-x64
-      demands:
-      - ImageOverride -equals PSMMS2022-OpenSSH-Secure
+      vmImage: windows-latest
     steps:
     - template: ./templates/install-vcpkg-dependencies.yml
       parameters:
@@ -29,9 +27,7 @@ stages:
   - job: InstallDeps_x86
     displayName: Install vcpkg Dependencies (x86)
     pool:
-      name: PS-PowerShell-x64
-      demands:
-      - ImageOverride -equals PSMMS2022-OpenSSH-Secure
+      vmImage: windows-latest
     steps:
     - template: ./templates/install-vcpkg-dependencies.yml
       parameters:
@@ -45,9 +41,7 @@ stages:
   - job: BuildPkg_x64
     displayName: Build Package (x64)
     pool:
-      name: PS-PowerShell-x64
-      demands:
-      - ImageOverride -equals PSMMS2022-OpenSSH-Secure
+      vmImage: windows-latest
     steps:
     - template: ./templates/build-win32-openssh-job.yml
       parameters:
@@ -60,9 +54,7 @@ stages:
   - job: BuildPkg_x86
     displayName: Build Package (x86)
     pool:
-      name: PS-PowerShell-x64
-      demands:
-      - ImageOverride -equals PSMMS2022-OpenSSH-Secure
+      vmImage: windows-latest
     steps:
     - template: ./templates/build-win32-openssh-job.yml
       parameters:

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -23,6 +23,7 @@ stages:
       parameters:
         triplet: x64-custom
         artifactSuffix: x64
+        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
 
   - job: InstallDeps_x86
     displayName: Install vcpkg Dependencies (x86)
@@ -33,6 +34,7 @@ stages:
       parameters:
         triplet: x86-custom
         artifactSuffix: x86
+        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
 
 - stage: Build
   displayName: Build Win32-OpenSSH
@@ -50,6 +52,8 @@ stages:
         artifactSuffix: x64
         dependenciesArtifactName: vcpkg-dependencies-x64
         includeConfig: true
+        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
+
 
   - job: BuildPkg_x86
     displayName: Build Package (x86)
@@ -62,6 +66,7 @@ stages:
         buildOutputDir: Win32
         artifactSuffix: x86
         dependenciesArtifactName: vcpkg-dependencies-x86
+        vcpkgCacheDir: '$(Build.SourcesDirectory)/binary-cache'
 
 - stage: Test
   displayName: Test Win32-OpenSSH

--- a/.azdo/templates/build-win32-openssh-job.yml
+++ b/.azdo/templates/build-win32-openssh-job.yml
@@ -10,10 +10,13 @@ parameters:
 - name: includeConfig
   type: boolean
   default: false
+- name: vcpkgCacheDir
+  type: string
 
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    mkdir "${{ parameters.vcpkgCacheDir }}"
     git clone https://github.com/microsoft/vcpkg
     cd vcpkg
     & ./bootstrap-vcpkg.bat
@@ -25,21 +28,15 @@ steps:
   inputs:
     buildType: current
     artifactName: ${{ parameters.dependenciesArtifactName }}
-    targetPath: '$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed'
-
-- pwsh: |
-    $folder = '${{ parameters.nativeHostArch }}' + '-custom'
-    $source = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder"
-    $nested = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder/$folder"
-    New-Item -ItemType Directory -Path $nested -Force
-    Get-ChildItem -Path $source | Where-Object { $_.name -ne $folder } | Move-Item -Destination $nested
-  displayName: Move vcpkg dependencies to expected location
+    targetPath: '${{ parameters.vcpkgCacheDir }}'
 
 - pwsh: |
     $nativeArch = '${{ parameters.nativeHostArch }}'
     Import-Module -Name "$(Build.SourcesDirectory)/contrib/win32/openssh/AzDOBuildTools" -Force
     Invoke-AzDOBuild -NativeHostArch $nativeArch
   displayName: Build Win32-OpenSSH (${{ parameters.nativeHostArch }})
+  env:
+    VCPKG_BINARY_SOURCES: "clear;files,${{ parameters.vcpkgCacheDir }},readwrite"
 
 - pwsh: |
     $buildOutPath = "$(Build.SourcesDirectory)/bin"

--- a/.azdo/templates/build-win32-openssh-job.yml
+++ b/.azdo/templates/build-win32-openssh-job.yml
@@ -28,7 +28,7 @@ steps:
     targetPath: '$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed'
 
 - pwsh: |
-    $folder = $${{ parameters.nativeHostArch }}-custom
+    $folder = "$${{ parameters.nativeHostArch }}-custom"
     $source = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder"
     $nested = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder/$folder"
     New-Item -ItemType Directory -Path $nested -Force

--- a/.azdo/templates/build-win32-openssh-job.yml
+++ b/.azdo/templates/build-win32-openssh-job.yml
@@ -28,6 +28,14 @@ steps:
     targetPath: '$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed'
 
 - pwsh: |
+    $folder = $${{ parameters.nativeHostArch }}-custom
+    $source = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder"
+    $nested = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder/$folder"
+    New-Item -ItemType Directory -Path $nested -Force
+    Get-ChildItem -Path $source | Where-Object { $_.name -ne $folder } | Move-Item -Destination $nested
+  displayName: Move vcpkg dependencies to expected location
+
+- pwsh: |
     $nativeArch = '${{ parameters.nativeHostArch }}'
     Import-Module -Name "$(Build.SourcesDirectory)/contrib/win32/openssh/AzDOBuildTools" -Force
     Invoke-AzDOBuild -NativeHostArch $nativeArch

--- a/.azdo/templates/build-win32-openssh-job.yml
+++ b/.azdo/templates/build-win32-openssh-job.yml
@@ -28,7 +28,7 @@ steps:
     targetPath: '$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed'
 
 - pwsh: |
-    $folder = $${{ parameters.nativeHostArch }} + "-custom"
+    $folder = '${{ parameters.nativeHostArch }}' + '-custom'
     $source = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder"
     $nested = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder/$folder"
     New-Item -ItemType Directory -Path $nested -Force

--- a/.azdo/templates/build-win32-openssh-job.yml
+++ b/.azdo/templates/build-win32-openssh-job.yml
@@ -28,7 +28,7 @@ steps:
     targetPath: '$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed'
 
 - pwsh: |
-    $folder = "$${{ parameters.nativeHostArch }}-custom"
+    $folder = $${{ parameters.nativeHostArch }} + "-custom"
     $source = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder"
     $nested = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed/$folder/$folder"
     New-Item -ItemType Directory -Path $nested -Force

--- a/.azdo/templates/install-vcpkg-dependencies.yml
+++ b/.azdo/templates/install-vcpkg-dependencies.yml
@@ -28,7 +28,7 @@ steps:
 
 - pwsh: |
     $ErrorActionPreference = 'Stop'
-    mkdir "$(vcpkgCacheDir)"
+    mkdir "${{ parameters.vcpkgCacheDir }}"
     git clone https://github.com/microsoft/vcpkg
     cd vcpkg
     & ./bootstrap-vcpkg.bat

--- a/.azdo/templates/install-vcpkg-dependencies.yml
+++ b/.azdo/templates/install-vcpkg-dependencies.yml
@@ -3,6 +3,8 @@ parameters:
   type: string
 - name: artifactSuffix
   type: string
+- name: vcpkgCacheDir
+  type: string
 
 steps:
 - pwsh: |
@@ -26,6 +28,7 @@ steps:
 
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    mkdir "$(vcpkgCacheDir)"
     git clone https://github.com/microsoft/vcpkg
     cd vcpkg
     & ./bootstrap-vcpkg.bat
@@ -49,7 +52,7 @@ steps:
 
 - pwsh: |
     $artifactSuffix = '${{ parameters.artifactSuffix }}'
-    $vcpkgInstalledPath = "$(Build.SourcesDirectory)/contrib/win32/openssh/vcpkg_installed"
+    $vcpkgInstalledPath = "$(vcpkgCacheDir)"
     
     if (Test-Path -Path $vcpkgInstalledPath) {
       Write-Verbose -Verbose "vcpkg_installed directory contents:"

--- a/.azdo/templates/install-vcpkg-dependencies.yml
+++ b/.azdo/templates/install-vcpkg-dependencies.yml
@@ -52,7 +52,7 @@ steps:
 
 - pwsh: |
     $artifactSuffix = '${{ parameters.artifactSuffix }}'
-    $vcpkgInstalledPath = "$(vcpkgCacheDir)"
+    $vcpkgInstalledPath = "${{ parameters.vcpkgCacheDir }}"
     
     if (Test-Path -Path $vcpkgInstalledPath) {
       Write-Verbose -Verbose "vcpkg_installed directory contents:"

--- a/.azdo/templates/install-vcpkg-dependencies.yml
+++ b/.azdo/templates/install-vcpkg-dependencies.yml
@@ -49,6 +49,8 @@ steps:
       Pop-Location
     }
   displayName: Install vcpkg dependencies (${{ parameters.triplet }})
+  env:
+    VCPKG_BINARY_SOURCES: "clear;files,${{ parameters.vcpkgCacheDir }},readwrite"
 
 - pwsh: |
     $artifactSuffix = '${{ parameters.artifactSuffix }}'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- change pool to windows-latest image for all build steps
- fix where build dependencies are downloaded to (build wasn't finding them, so they were being rebuilt)
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- builds on `latestw_all` branch are still timing out
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
