### PR TITLE
[ssh-keygen] fix fido2 key filename translation on Windows

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -3210,7 +3210,7 @@ sk_suffix(const char *application, const uint8_t *user, size_t userlen)
 	else
 		ret = xstrdup(application);
 
-#ifdef WINDOWS 
+#ifdef WINDOWS
 	/* replace any additional colons with underscores so filename is valid */
 	while ((cp = strchr(ret, ':')) != NULL)
 		*cp = '_';

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -3210,6 +3210,12 @@ sk_suffix(const char *application, const uint8_t *user, size_t userlen)
 	else
 		ret = xstrdup(application);
 
+#ifdef WINDOWS 
+	/* replace any additional colons with underscores so filename is valid */
+	while ((cp = strchr(ret, ':')) != NULL)
+		*cp = '_';
+#endif
+
 	/* Count trailing zeros in user */
 	for (i = 0; i < userlen; i++) {
 		if (user[userlen - i - 1] != 0)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- fix https://github.com/PowerShell/Win32-OpenSSH/issues/2418
<!-- Summarize your PR between here and the checklist. -->

