### PR TITLE
Fix file permissions check

### DIFF
--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -712,7 +712,7 @@ function Invoke-OpenSSHBashTests
     } else {
         # Install cygwin
         Write-Host "Installing cygwin using chocolatey to $env:SystemDrive\cygwin folder"
-        choco install cygwin -y --params "/InstallDir:$env:SystemDrive\cygwin\ /NoStartMenu"
+        choco install cygwin --version 3.6.6 -y --params "/InstallDir:$env:SystemDrive\cygwin\ /NoStartMenu"
 
         if (Test-Path $env:SystemDrive\cygwin\bin\sh.exe) {
             $bashPath = "$env:SystemDrive\cygwin\bin\sh.exe"

--- a/contrib/win32/openssh/OpenSSHTestHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHTestHelper.psm1
@@ -712,7 +712,7 @@ function Invoke-OpenSSHBashTests
     } else {
         # Install cygwin
         Write-Host "Installing cygwin using chocolatey to $env:SystemDrive\cygwin folder"
-        choco install cygwin --version 3.6.6 -y --params "/InstallDir:$env:SystemDrive\cygwin\ /NoStartMenu"
+        choco install cygwin -y --params "/InstallDir:$env:SystemDrive\cygwin\ /NoStartMenu"
 
         if (Test-Path $env:SystemDrive\cygwin\bin\sh.exe) {
             $bashPath = "$env:SystemDrive\cygwin\bin\sh.exe"

--- a/contrib/win32/win32compat/w32-sshfileperm.c
+++ b/contrib/win32/win32compat/w32-sshfileperm.c
@@ -133,7 +133,7 @@ check_secure_file_permission(const char *input_path, struct passwd * pw, int rea
 		    EqualSid(current_trustee_sid, user_sid) ||
 		    (ti_sid && EqualSid(current_trustee_sid, ti_sid))) {
 			continue;
-		} else if (read_ok && (current_access_mask & (FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA)) == 0 ) {
+		} else if (read_ok && (current_access_mask & (FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | WRITE_DAC | WRITE_OWNER | DELETE )) == 0 ) {
 			/* if read is allowed, allow ACES that do not give write access*/
 			continue;
 		} else {
@@ -250,7 +250,7 @@ check_secure_folder_permission(const wchar_t* path_utf16, int read_ok)
 			IsWellKnownSid(current_trustee_sid, WinLocalSystemSid)) {
 			continue;
 		}
-		else if (read_ok && (current_access_mask & (FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA)) == 0) {
+		else if (read_ok && (current_access_mask & (FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | WRITE_DAC | WRITE_OWNER | DELETE)) == 0) {
 			/* if read is allowed, allow ACES that do not give write access*/
 			continue;
 		}

--- a/contrib/win32/win32compat/w32-sshfileperm.c
+++ b/contrib/win32/win32compat/w32-sshfileperm.c
@@ -46,6 +46,12 @@
 #define COMMA_SPACE_LEN			2
 #define BACKSLASH_LEN			1
 
+/* Access rights that are considered write-class for SSH file/folder security checks.
+ * No non-trusted principal may hold any of these rights on a secured path. */
+#define SSH_SECURE_WRITE_MASK \
+	(FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | \
+	 WRITE_DAC | WRITE_OWNER | DELETE)
+
 extern int log_on_stderr;
 
 /*
@@ -133,7 +139,7 @@ check_secure_file_permission(const char *input_path, struct passwd * pw, int rea
 		    EqualSid(current_trustee_sid, user_sid) ||
 		    (ti_sid && EqualSid(current_trustee_sid, ti_sid))) {
 			continue;
-		} else if (read_ok && (current_access_mask & (FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | WRITE_DAC | WRITE_OWNER | DELETE )) == 0 ) {
+		} else if (read_ok && (current_access_mask & SSH_SECURE_WRITE_MASK) == 0) {
 			/* if read is allowed, allow ACES that do not give write access*/
 			continue;
 		} else {
@@ -250,7 +256,7 @@ check_secure_folder_permission(const wchar_t* path_utf16, int read_ok)
 			IsWellKnownSid(current_trustee_sid, WinLocalSystemSid)) {
 			continue;
 		}
-		else if (read_ok && (current_access_mask & (FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | WRITE_DAC | WRITE_OWNER | DELETE)) == 0) {
+		else if (read_ok && (current_access_mask & SSH_SECURE_WRITE_MASK) == 0) {
 			/* if read is allowed, allow ACES that do not give write access*/
 			continue;
 		}

--- a/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
+++ b/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
@@ -193,12 +193,10 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-authorized_keys-negative(other account has ChangePermissions on authorized_keys file)"  -skip:$skip {
-            #setup clean ACL then grant PwdUser ChangePermissions (WRITE_DAC)
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "ChangePermissions"
 
-            #Run
             Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
             ssh -p $port -E $sshlog $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
@@ -209,12 +207,10 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-authorized_keys-negative(other account has TakeOwnership on authorized_keys file)"  -skip:$skip {
-            #setup clean ACL then grant PwdUser TakeOwnership (WRITE_OWNER)
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "TakeOwnership"
 
-            #Run
             Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
             ssh -p $port -E $sshlog $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
@@ -225,12 +221,10 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-authorized_keys-negative(other account has Delete on authorized_keys file)"  -skip:$skip {
-            #setup clean ACL then grant PwdUser Delete (DELETE)
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "Delete"
 
-            #Run
             Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
             ssh -p $port -E $sshlog $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
@@ -245,7 +239,6 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objPwdUserSid -FullAccessNeeded $adminsSid,$systemSid,$objPwdUser -confirm:$false
 
-            #Run
             Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
             ssh -p $port -E $sshlog $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0

--- a/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
+++ b/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
@@ -166,7 +166,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
 
             #Run
             Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
-            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            ssh -p $port -E $sshlog -o "PasswordAuthentication=no" $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             Stop-SSHDTestDaemon -Port $port                  
             sleep $sshdDelay                  
@@ -184,7 +184,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
 
             #Run
             Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
-            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            ssh -p $port -E $sshlog -o "PasswordAuthentication=no" $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0            
             Stop-SSHDTestDaemon -Port $port
             sleep $sshdDelay
@@ -193,12 +193,12 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-authorized_keys-negative(other account has ChangePermissions on authorized_keys file)"  -skip:$skip {
-            Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
+            Repair-AuthorizedKeyPermission -Filepath $authorizedkeyPath -confirm:$false
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "ChangePermissions"
 
             Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
-            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            ssh -p $port -E $sshlog -o "PasswordAuthentication=no" $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             Stop-SSHDTestDaemon -Port $port
             sleep $sshdDelay
@@ -207,12 +207,12 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-authorized_keys-negative(other account has TakeOwnership on authorized_keys file)"  -skip:$skip {
-            Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
+            Repair-AuthorizedKeyPermission -Filepath $authorizedkeyPath -confirm:$false
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "TakeOwnership"
 
             Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
-            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            ssh -p $port -E $sshlog -o "PasswordAuthentication=no" $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             Stop-SSHDTestDaemon -Port $port
             sleep $sshdDelay
@@ -221,12 +221,12 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-authorized_keys-negative(other account has Delete on authorized_keys file)"  -skip:$skip {
-            Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
+            Repair-AuthorizedKeyPermission -Filepath $authorizedkeyPath -confirm:$false
             $objPwdUserSid = Get-UserSid -User $PwdUser
             Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "Delete"
 
             Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
-            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            ssh -p $port -E $sshlog -o "PasswordAuthentication=no" $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             Stop-SSHDTestDaemon -Port $port
             sleep $sshdDelay
@@ -240,7 +240,7 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objPwdUserSid -FullAccessNeeded $adminsSid,$systemSid,$objPwdUser -confirm:$false
 
             Start-SSHDTestDaemon -WorkDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
-            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            ssh -p $port -E $sshlog -o "PasswordAuthentication=no" $ssouser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             Stop-SSHDTestDaemon -Port $port
             sleep $sshdDelay

--- a/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
+++ b/regress/pesterTests/Authorized_keys_fileperm.Tests.ps1
@@ -192,6 +192,54 @@ Describe "Tests for authorized_keys file permission" -Tags "CI" {
             $sshdlog | Should Contain "Authentication refused."
         }
 
+        It "$tC.$tI-authorized_keys-negative(other account has ChangePermissions on authorized_keys file)"  -skip:$skip {
+            #setup clean ACL then grant PwdUser ChangePermissions (WRITE_DAC)
+            Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
+            $objPwdUserSid = Get-UserSid -User $PwdUser
+            Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "ChangePermissions"
+
+            #Run
+            Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
+            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            $LASTEXITCODE | Should Not Be 0
+            Stop-SSHDTestDaemon -Port $port
+            sleep $sshdDelay
+            $sshlog | Should Contain "Permission denied"
+            $sshdlog | Should Contain "Authentication refused."
+        }
+
+        It "$tC.$tI-authorized_keys-negative(other account has TakeOwnership on authorized_keys file)"  -skip:$skip {
+            #setup clean ACL then grant PwdUser TakeOwnership (WRITE_OWNER)
+            Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
+            $objPwdUserSid = Get-UserSid -User $PwdUser
+            Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "TakeOwnership"
+
+            #Run
+            Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
+            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            $LASTEXITCODE | Should Not Be 0
+            Stop-SSHDTestDaemon -Port $port
+            sleep $sshdDelay
+            $sshlog | Should Contain "Permission denied"
+            $sshdlog | Should Contain "Authentication refused."
+        }
+
+        It "$tC.$tI-authorized_keys-negative(other account has Delete on authorized_keys file)"  -skip:$skip {
+            #setup clean ACL then grant PwdUser Delete (DELETE)
+            Repair-FilePermission -Filepath $authorizedkeyPath -Owner $objUserSid -FullAccessNeeded $adminsSid,$systemSid,$objUserSid -confirm:$false
+            $objPwdUserSid = Get-UserSid -User $PwdUser
+            Set-FilePermission -FilePath $authorizedkeyPath -User $objPwdUserSid -Perm "Delete"
+
+            #Run
+            Start-SSHDTestDaemon -workDir $opensshbinpath -Arguments "-d -f $sshdconfig -o `"AuthorizedKeysFile .testssh/authorized_keys`" -E $sshdlog" -Port $port
+            ssh -p $port -E $sshlog $ssouser@$server echo 1234
+            $LASTEXITCODE | Should Not Be 0
+            Stop-SSHDTestDaemon -Port $port
+            sleep $sshdDelay
+            $sshlog | Should Contain "Permission denied"
+            $sshdlog | Should Contain "Authentication refused."
+        }
+
         It "$tC.$tI-authorized_keys-negative(authorized_keys is owned by other non-admin user)"  -skip:$skip {
             #setup to have PwdUser as owner and grant it full control            
             $objPwdUserSid = Get-UserSid -User $PwdUser

--- a/regress/pesterTests/Hostkey_fileperm.Tests.ps1
+++ b/regress/pesterTests/Hostkey_fileperm.Tests.ps1
@@ -148,5 +148,47 @@ Describe "Tests for host keys file permission" -Tags "CI" {
             $logPath | Should Contain "bad permissions"
         }
 
+        It "$tC.$tI-Host keys-negative (other account has ChangePermissions on private key file)" {
+            #setup clean ACL then grant ssouser ChangePermissions (WRITE_DAC)
+            Repair-FilePermission -Filepath $hostKeyFilePath -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -confirm:$false
+            Repair-FilePermission -Filepath "$hostKeyFilePath.pub" -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -ReadAccessNeeded $everyOneSid -confirm:$false
+            Set-FilePermission -FilePath $hostKeyFilePath -UserSid $objUserSid -Perm "ChangePermissions"
+
+            #Run
+            Start-Process -FilePath sshd.exe -WorkingDirectory $($OpenSSHTestInfo['OpenSSHBinPath']) -ArgumentList @("-d", "-p $port", "-h $hostKeyFilePath", "-E $logPath") -NoNewWindow
+            WaitForValidation -LogPath $logPath -Length 1100
+
+            #validate file content contains bad permissions info.
+            $logPath | Should Contain "bad permissions"
+        }
+
+        It "$tC.$tI-Host keys-negative (other account has TakeOwnership on private key file)" {
+            #setup clean ACL then grant ssouser TakeOwnership (WRITE_OWNER)
+            Repair-FilePermission -Filepath $hostKeyFilePath -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -confirm:$false
+            Repair-FilePermission -Filepath "$hostKeyFilePath.pub" -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -ReadAccessNeeded $everyOneSid -confirm:$false
+            Set-FilePermission -FilePath $hostKeyFilePath -UserSid $objUserSid -Perm "TakeOwnership"
+
+            #Run
+            Start-Process -FilePath sshd.exe -WorkingDirectory $($OpenSSHTestInfo['OpenSSHBinPath']) -ArgumentList @("-d", "-p $port", "-h $hostKeyFilePath", "-E $logPath") -NoNewWindow
+            WaitForValidation -LogPath $logPath -Length 1100
+
+            #validate file content contains bad permissions info.
+            $logPath | Should Contain "bad permissions"
+        }
+
+        It "$tC.$tI-Host keys-negative (other account has Delete on private key file)" {
+            #setup clean ACL then grant ssouser Delete (DELETE)
+            Repair-FilePermission -Filepath $hostKeyFilePath -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -confirm:$false
+            Repair-FilePermission -Filepath "$hostKeyFilePath.pub" -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -ReadAccessNeeded $everyOneSid -confirm:$false
+            Set-FilePermission -FilePath $hostKeyFilePath -UserSid $objUserSid -Perm "Delete"
+
+            #Run
+            Start-Process -FilePath sshd.exe -WorkingDirectory $($OpenSSHTestInfo['OpenSSHBinPath']) -ArgumentList @("-d", "-p $port", "-h $hostKeyFilePath", "-E $logPath") -NoNewWindow
+            WaitForValidation -LogPath $logPath -Length 1100
+
+            #validate file content contains bad permissions info.
+            $logPath | Should Contain "bad permissions"
+        }
+
     }
 }

--- a/regress/pesterTests/Hostkey_fileperm.Tests.ps1
+++ b/regress/pesterTests/Hostkey_fileperm.Tests.ps1
@@ -149,44 +149,29 @@ Describe "Tests for host keys file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-Host keys-negative (other account has ChangePermissions on private key file)" {
-            #setup clean ACL then grant ssouser ChangePermissions (WRITE_DAC)
             Repair-FilePermission -Filepath $hostKeyFilePath -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -confirm:$false
             Repair-FilePermission -Filepath "$hostKeyFilePath.pub" -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -ReadAccessNeeded $everyOneSid -confirm:$false
             Set-FilePermission -FilePath $hostKeyFilePath -UserSid $objUserSid -Perm "ChangePermissions"
-
-            #Run
             Start-Process -FilePath sshd.exe -WorkingDirectory $($OpenSSHTestInfo['OpenSSHBinPath']) -ArgumentList @("-d", "-p $port", "-h $hostKeyFilePath", "-E $logPath") -NoNewWindow
             WaitForValidation -LogPath $logPath -Length 1100
-
-            #validate file content contains bad permissions info.
             $logPath | Should Contain "bad permissions"
         }
 
         It "$tC.$tI-Host keys-negative (other account has TakeOwnership on private key file)" {
-            #setup clean ACL then grant ssouser TakeOwnership (WRITE_OWNER)
             Repair-FilePermission -Filepath $hostKeyFilePath -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -confirm:$false
             Repair-FilePermission -Filepath "$hostKeyFilePath.pub" -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -ReadAccessNeeded $everyOneSid -confirm:$false
             Set-FilePermission -FilePath $hostKeyFilePath -UserSid $objUserSid -Perm "TakeOwnership"
-
-            #Run
             Start-Process -FilePath sshd.exe -WorkingDirectory $($OpenSSHTestInfo['OpenSSHBinPath']) -ArgumentList @("-d", "-p $port", "-h $hostKeyFilePath", "-E $logPath") -NoNewWindow
             WaitForValidation -LogPath $logPath -Length 1100
-
-            #validate file content contains bad permissions info.
             $logPath | Should Contain "bad permissions"
         }
 
         It "$tC.$tI-Host keys-negative (other account has Delete on private key file)" {
-            #setup clean ACL then grant ssouser Delete (DELETE)
             Repair-FilePermission -Filepath $hostKeyFilePath -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -confirm:$false
             Repair-FilePermission -Filepath "$hostKeyFilePath.pub" -Owners $adminsSid -FullAccessNeeded $systemSid,$adminsSid -ReadAccessNeeded $everyOneSid -confirm:$false
             Set-FilePermission -FilePath $hostKeyFilePath -UserSid $objUserSid -Perm "Delete"
-
-            #Run
             Start-Process -FilePath sshd.exe -WorkingDirectory $($OpenSSHTestInfo['OpenSSHBinPath']) -ArgumentList @("-d", "-p $port", "-h $hostKeyFilePath", "-E $logPath") -NoNewWindow
             WaitForValidation -LogPath $logPath -Length 1100
-
-            #validate file content contains bad permissions info.
             $logPath | Should Contain "bad permissions"
         }
 

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -633,7 +633,7 @@ Describe "Setup Tests" -Tags "Setup" {
 
             net start sshd
             $LASTEXITCODE | Should Be 0
-
+            Start-Sleep -Seconds 1 # ensure event is logged before querying 
             $events = wevtutil qe "OpenSSH/Operational" /f:text
             ($events | Out-String) | Should Match "write access is granted"
         }
@@ -650,7 +650,7 @@ Describe "Setup Tests" -Tags "Setup" {
 
             net start sshd
             $LASTEXITCODE | Should Be 0
-
+            Start-Sleep -Seconds 1 # ensure event is logged before querying 
             $events = wevtutil qe "OpenSSH/Operational" /f:text
             ($events | Out-String) | Should Match "write access is granted"
         }
@@ -662,18 +662,13 @@ Describe "Setup Tests" -Tags "Setup" {
             # Grant Delete to Authenticated Users using explicit inheritance flags to match the
             # existing ReadAndExecute ACE, avoiding OS merging ambiguity. Advisory warning, does not block startup.
             $acl = Get-Acl $sshFolderPath
-            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-                $authenticatedUserSid,
-                [System.Security.AccessControl.FileSystemRights]::ReadAndExecute -bor [System.Security.AccessControl.FileSystemRights]::Delete,
-                [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit,
-                [System.Security.AccessControl.PropagationFlags]::None,
-                [System.Security.AccessControl.AccessControlType]::Allow)
-            $acl.SetAccessRule($accessRule)
+            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($authenticatedUserSid, "Delete", "Allow")
+            $acl.AddAccessRule($accessRule)
             Set-Acl -Path $sshFolderPath -AclObject $acl
 
             net start sshd
             $LASTEXITCODE | Should Be 0
-
+            Start-Sleep -Seconds 1 # ensure event is logged before querying 
             $events = wevtutil qe "OpenSSH/Operational" /f:text
             ($events | Out-String) | Should Match "write access is granted"
         }

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -606,4 +606,85 @@ Describe "Setup Tests" -Tags "Setup" {
             $LASTEXITCODE | Should Be 0
         }
     }
+
+    Context "$tC - Validate folder permission warnings for ChangePermissions, TakeOwnership, and Delete" {
+        BeforeAll {
+            $tI = 1
+            $sshFolderPath = Join-Path $env:ProgramData "ssh"
+            $sshACL = $null
+            if (Test-Path -Path $sshFolderPath) {
+                $sshACL = Get-Acl $sshFolderPath
+            }
+            if ((Get-Service sshd).Status -eq 'Running') {
+                net stop sshd
+            }
+            # Register ETW manifest to capture OpenSSH events in the event log
+            $etwman = Join-Path $binPath "openssh-events.man"
+            if (Test-Path $etwman -PathType Leaf) {
+                wevtutil im "$etwman" 2>&1 | Out-Null
+            }
+        }
+        BeforeEach {
+            # Clear and enable the Operational event log channel before each test
+            wevtutil sl "OpenSSH/Operational" /e:false /q:true | Out-Null
+            wevtutil cl "OpenSSH/Operational" | Out-Null
+            wevtutil sl "OpenSSH/Operational" /e:true /q:true | Out-Null
+        }
+        AfterEach {
+            $tI++
+            net stop sshd
+            if ($sshACL -ne $null) {
+                Set-Acl -Path $sshFolderPath -AclObject $sshACL
+            }
+        }
+        AfterAll {
+            $tC++
+            $etwman = Join-Path $binPath "openssh-events.man"
+            if (Test-Path $etwman -PathType Leaf) {
+                wevtutil um "$etwman" 2>&1 | Out-Null
+            }
+        }
+
+        It "$tC.$tI - SSHD starts successfully and logs warning when other account has ChangePermissions on ssh folder" {
+            # Grant ChangePermissions (WRITE_DAC) to Authenticated Users - advisory warning, does not block startup
+            $acl = Get-Acl $sshFolderPath
+            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($authenticatedUserSid, "ChangePermissions", "Allow")
+            $acl.AddAccessRule($accessRule)
+            Set-Acl -Path $sshFolderPath -AclObject $acl
+
+            net start sshd
+            $LASTEXITCODE | Should Be 0
+
+            $events = wevtutil qe "OpenSSH/Operational" /f:text
+            ($events | Out-String) | Should Match "write access is granted"
+        }
+
+        It "$tC.$tI - SSHD starts successfully and logs warning when other account has TakeOwnership on ssh folder" {
+            # Grant TakeOwnership (WRITE_OWNER) to Authenticated Users - advisory warning, does not block startup
+            $acl = Get-Acl $sshFolderPath
+            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($authenticatedUserSid, "TakeOwnership", "Allow")
+            $acl.AddAccessRule($accessRule)
+            Set-Acl -Path $sshFolderPath -AclObject $acl
+
+            net start sshd
+            $LASTEXITCODE | Should Be 0
+
+            $events = wevtutil qe "OpenSSH/Operational" /f:text
+            ($events | Out-String) | Should Match "write access is granted"
+        }
+
+        It "$tC.$tI - SSHD starts successfully and logs warning when other account has Delete on ssh folder" {
+            # Grant Delete to Authenticated Users - advisory warning, does not block startup
+            $acl = Get-Acl $sshFolderPath
+            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($authenticatedUserSid, "Delete", "Allow")
+            $acl.AddAccessRule($accessRule)
+            Set-Acl -Path $sshFolderPath -AclObject $acl
+
+            net start sshd
+            $LASTEXITCODE | Should Be 0
+
+            $events = wevtutil qe "OpenSSH/Operational" /f:text
+            ($events | Out-String) | Should Match "write access is granted"
+        }
+    }
 }

--- a/regress/pesterTests/Setup.Tests.ps1
+++ b/regress/pesterTests/Setup.Tests.ps1
@@ -572,6 +572,17 @@ Describe "Setup Tests" -Tags "Setup" {
             if ((Get-Service sshd).Status -eq 'Running') {
                 net stop sshd
             }
+            # Register ETW manifest to capture OpenSSH events in the event log
+            $etwman = Join-Path $binPath "openssh-events.man"
+            if (Test-Path $etwman -PathType Leaf) {
+                wevtutil im "$etwman" 2>&1 | Out-Null
+            }
+        }
+        BeforeEach {
+            # Clear and enable the Operational event log channel before each test
+            wevtutil sl "OpenSSH/Operational" /e:false /q:true | Out-Null
+            wevtutil cl "OpenSSH/Operational" | Out-Null
+            wevtutil sl "OpenSSH/Operational" /e:true /q:true | Out-Null
         }
         AfterAll {
             $tC++
@@ -580,6 +591,10 @@ Describe "Setup Tests" -Tags "Setup" {
             }
             if ($sshACL -eq $null) {
                 Remove-Item -Path $sshFolderPath -Recurse -Force
+            }
+            $etwman = Join-Path $binPath "openssh-events.man"
+            if (Test-Path $etwman -PathType Leaf) {
+                wevtutil um "$etwman" 2>&1 | Out-Null
             }
         }
         AfterEach {
@@ -605,47 +620,11 @@ Describe "Setup Tests" -Tags "Setup" {
             net start sshd
             $LASTEXITCODE | Should Be 0
         }
-    }
-
-    Context "$tC - Validate folder permission warnings for ChangePermissions, TakeOwnership, and Delete" {
-        BeforeAll {
-            $tI = 1
-            $sshFolderPath = Join-Path $env:ProgramData "ssh"
-            $sshACL = $null
-            if (Test-Path -Path $sshFolderPath) {
-                $sshACL = Get-Acl $sshFolderPath
-            }
-            if ((Get-Service sshd).Status -eq 'Running') {
-                net stop sshd
-            }
-            # Register ETW manifest to capture OpenSSH events in the event log
-            $etwman = Join-Path $binPath "openssh-events.man"
-            if (Test-Path $etwman -PathType Leaf) {
-                wevtutil im "$etwman" 2>&1 | Out-Null
-            }
-        }
-        BeforeEach {
-            # Clear and enable the Operational event log channel before each test
-            wevtutil sl "OpenSSH/Operational" /e:false /q:true | Out-Null
-            wevtutil cl "OpenSSH/Operational" | Out-Null
-            wevtutil sl "OpenSSH/Operational" /e:true /q:true | Out-Null
-        }
-        AfterEach {
-            $tI++
-            net stop sshd
-            if ($sshACL -ne $null) {
-                Set-Acl -Path $sshFolderPath -AclObject $sshACL
-            }
-        }
-        AfterAll {
-            $tC++
-            $etwman = Join-Path $binPath "openssh-events.man"
-            if (Test-Path $etwman -PathType Leaf) {
-                wevtutil um "$etwman" 2>&1 | Out-Null
-            }
-        }
 
         It "$tC.$tI - SSHD starts successfully and logs warning when other account has ChangePermissions on ssh folder" {
+            if (-not (Test-Path -Path $sshFolderPath)) {
+                New-Item -Path $sshFolderPath -ItemType Directory -Force
+            }
             # Grant ChangePermissions (WRITE_DAC) to Authenticated Users - advisory warning, does not block startup
             $acl = Get-Acl $sshFolderPath
             $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($authenticatedUserSid, "ChangePermissions", "Allow")
@@ -660,6 +639,9 @@ Describe "Setup Tests" -Tags "Setup" {
         }
 
         It "$tC.$tI - SSHD starts successfully and logs warning when other account has TakeOwnership on ssh folder" {
+            if (-not (Test-Path -Path $sshFolderPath)) {
+                New-Item -Path $sshFolderPath -ItemType Directory -Force
+            }
             # Grant TakeOwnership (WRITE_OWNER) to Authenticated Users - advisory warning, does not block startup
             $acl = Get-Acl $sshFolderPath
             $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($authenticatedUserSid, "TakeOwnership", "Allow")
@@ -674,10 +656,19 @@ Describe "Setup Tests" -Tags "Setup" {
         }
 
         It "$tC.$tI - SSHD starts successfully and logs warning when other account has Delete on ssh folder" {
-            # Grant Delete to Authenticated Users - advisory warning, does not block startup
+            if (-not (Test-Path -Path $sshFolderPath)) {
+                New-Item -Path $sshFolderPath -ItemType Directory -Force
+            }
+            # Grant Delete to Authenticated Users using explicit inheritance flags to match the
+            # existing ReadAndExecute ACE, avoiding OS merging ambiguity. Advisory warning, does not block startup.
             $acl = Get-Acl $sshFolderPath
-            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($authenticatedUserSid, "Delete", "Allow")
-            $acl.AddAccessRule($accessRule)
+            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+                $authenticatedUserSid,
+                [System.Security.AccessControl.FileSystemRights]::ReadAndExecute -bor [System.Security.AccessControl.FileSystemRights]::Delete,
+                [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit,
+                [System.Security.AccessControl.PropagationFlags]::None,
+                [System.Security.AccessControl.AccessControlType]::Allow)
+            $acl.SetAccessRule($accessRule)
             Set-Acl -Path $sshFolderPath -AclObject $acl
 
             net start sshd

--- a/regress/pesterTests/Userkey_fileperm.Tests.ps1
+++ b/regress/pesterTests/Userkey_fileperm.Tests.ps1
@@ -134,5 +134,38 @@ Describe "Tests for user Key file permission" -Tags "CI" {
 
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
         }
+
+        It "$tC.$tI-ssh with private key file -- negative(other account has ChangePermissions on private key file)" {
+            #setup clean ACL then grant ssouser ChangePermissions (WRITE_DAC)
+            Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
+            Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "ChangePermissions"
+
+            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $LASTEXITCODE | Should Not Be 0
+
+            $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
+        }
+
+        It "$tC.$tI-ssh with private key file -- negative(other account has TakeOwnership on private key file)" {
+            #setup clean ACL then grant ssouser TakeOwnership (WRITE_OWNER)
+            Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
+            Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "TakeOwnership"
+
+            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $LASTEXITCODE | Should Not Be 0
+
+            $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
+        }
+
+        It "$tC.$tI-ssh with private key file -- negative(other account has Delete on private key file)" {
+            #setup clean ACL then grant ssouser Delete (DELETE)
+            Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
+            Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "Delete"
+
+            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $LASTEXITCODE | Should Not Be 0
+
+            $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
+        }
     }
 }

--- a/regress/pesterTests/Userkey_fileperm.Tests.ps1
+++ b/regress/pesterTests/Userkey_fileperm.Tests.ps1
@@ -119,7 +119,7 @@ Describe "Tests for user Key file permission" -Tags "CI" {
             Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $currentUser,$adminsSid,$systemSid -ReadAccessNeeded $objUserSid -confirm:$false
 
             #Run
-            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $o = ssh -p $port -i $keyFilePath -E $logPath -o "PasswordAuthentication=no" $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
 
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
@@ -129,7 +129,7 @@ Describe "Tests for user Key file permission" -Tags "CI" {
             #setup to have ssouser as owner and grant it full control
             Repair-FilePermission -FilePath $keyFilePath -Owners $objUserSid -FullAccessNeeded $objUserSid,$adminsSid,$systemSid -ReadAccessNeeded $objUserSid -confirm:$false
 
-            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $o = ssh -p $port -i $keyFilePath -E $logPath -o "PasswordAuthentication=no" $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
 
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
@@ -138,7 +138,7 @@ Describe "Tests for user Key file permission" -Tags "CI" {
         It "$tC.$tI-ssh with private key file -- negative(other account has ChangePermissions on private key file)" {
             Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
             Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "ChangePermissions"
-            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $o = ssh -p $port -i $keyFilePath -E $logPath -o "PasswordAuthentication=no" $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
         }
@@ -146,7 +146,7 @@ Describe "Tests for user Key file permission" -Tags "CI" {
         It "$tC.$tI-ssh with private key file -- negative(other account has TakeOwnership on private key file)" {
             Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
             Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "TakeOwnership"
-            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $o = ssh -p $port -i $keyFilePath -E $logPath -o "PasswordAuthentication=no" $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
         }
@@ -154,7 +154,7 @@ Describe "Tests for user Key file permission" -Tags "CI" {
         It "$tC.$tI-ssh with private key file -- negative(other account has Delete on private key file)" {
             Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
             Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "Delete"
-            $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
+            $o = ssh -p $port -i $keyFilePath -E $logPath -o "PasswordAuthentication=no" $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
         }

--- a/regress/pesterTests/Userkey_fileperm.Tests.ps1
+++ b/regress/pesterTests/Userkey_fileperm.Tests.ps1
@@ -136,35 +136,26 @@ Describe "Tests for user Key file permission" -Tags "CI" {
         }
 
         It "$tC.$tI-ssh with private key file -- negative(other account has ChangePermissions on private key file)" {
-            #setup clean ACL then grant ssouser ChangePermissions (WRITE_DAC)
             Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
             Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "ChangePermissions"
-
             $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
-
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
         }
 
         It "$tC.$tI-ssh with private key file -- negative(other account has TakeOwnership on private key file)" {
-            #setup clean ACL then grant ssouser TakeOwnership (WRITE_OWNER)
             Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
             Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "TakeOwnership"
-
             $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
-
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
         }
 
         It "$tC.$tI-ssh with private key file -- negative(other account has Delete on private key file)" {
-            #setup clean ACL then grant ssouser Delete (DELETE)
             Repair-FilePermission -FilePath $keyFilePath -Owners $currentUserSid -FullAccessNeeded $adminsSid,$systemSid,$currentUserSid -confirm:$false
             Set-FilePermission -FilePath $keyFilePath -UserSid $objUserSid -Perm "Delete"
-
             $o = ssh -p $port -i $keyFilePath -E $logPath $pubKeyUser@$server echo 1234
             $LASTEXITCODE | Should Not Be 0
-
             $logPath | Should Contain "UNPROTECTED PRIVATE KEY FILE!"
         }
     }

--- a/regress/pesterTests/data/SSHD_Config
+++ b/regress/pesterTests/data/SSHD_Config
@@ -10,6 +10,7 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
+PerSourcePenalties no
 Port 47002
 #AddressFamily any
 #ListenAddress 0.0.0.0


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- expand file & folder permissions checks to include `WRITE_DAC`, `WRITE_OWNER`, and `DELETE`
- refactor code to use macro instead of duplicating definition of expected permissions
- add corresponding Pester tests
