### PR TITLE
Fix signal handling trap for xauth in Windows

### DIFF
--- a/clientloop.c
+++ b/clientloop.c
@@ -70,6 +70,7 @@
 # include <sys/time.h>
 #endif
 #include <sys/socket.h>
+#include <sys/wait.h>
 
 #include <ctype.h>
 #include <errno.h>

--- a/clientloop.c
+++ b/clientloop.c
@@ -285,6 +285,31 @@ client_x11_display_valid(const char *display)
 
 #define SSH_X11_PROTO		"MIT-MAGIC-COOKIE-1"
 #define X11_TIMEOUT_SLACK	60
+#ifdef WINDOWS
+/*
+ * Keep Windows xauth process launch in one helper so all subprocess flags and
+ * argv handling stay consistent in this signal/console-sensitive path.
+ */
+static pid_t
+client_x11_run_xauth_for_windows(const char *cmd, arglist *args, FILE **f)
+{
+	u_int flags = SSH_SUBPROCESS_STDERR_DISCARD |
+	    SSH_SUBPROCESS_UNSAFE_PATH | SSH_SUBPROCESS_PRESERVE_ENV;
+	u_int i;
+
+	if (f != NULL)
+		flags |= SSH_SUBPROCESS_STDOUT_CAPTURE;
+	else
+		flags |= SSH_SUBPROCESS_STDOUT_DISCARD;
+
+	for (i = 0; i < args->num; i++)
+		debug3_f("xauth argv[%u]: %s", i, args->list[i]);
+
+	return subprocess("xauth", cmd, args->num, args->list, f, flags,
+	    NULL, NULL, NULL);
+}
+#endif
+
 int
 client_x11_get_proto(struct ssh *ssh, const char *display,
     const char *xauth_path, u_int trusted, u_int timeout,
@@ -388,8 +413,34 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 				channel_set_x11_refuse_time(ssh,
 				    x11_refuse_time);
 			}
+#ifdef WINDOWS
+			{
+				int status;
+				pid_t pid;
+				arglist args;
+
+				memset(&args, 0, sizeof(args));
+				addargs(&args, "%s", xauth_path);
+				addargs(&args, "-f");
+				addargs(&args, "%s", xauthfile);
+				addargs(&args, "generate");
+				addargs(&args, "%s", display);
+				addargs(&args, "%s", SSH_X11_PROTO);
+				addargs(&args, "untrusted");
+				if (timeout != 0) {
+					addargs(&args, "timeout");
+					addargs(&args, "%u", x11_timeout_real);
+				}
+				pid = client_x11_run_xauth_for_windows(cmd, &args, NULL);
+				if (pid != 0 && waitpid(pid, &status, 0) == pid &&
+				    WIFEXITED(status) && WEXITSTATUS(status) == 0)
+					generated = 1;
+				freeargs(&args);
+			}
+#else
 			if (system(cmd) == 0)
 				generated = 1;
+#endif
 			free(cmd);
 		}
 
@@ -410,12 +461,39 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 			    generated ? xauthfile : "",
 			    display);
 			debug2("x11_get_proto: %s", cmd);
+#ifdef WINDOWS
+			{
+				int status;
+				pid_t pid;
+				arglist args;
+
+				memset(&args, 0, sizeof(args));
+				addargs(&args, "%s", xauth_path);
+				if (generated) {
+					addargs(&args, "-f");
+					addargs(&args, "%s", xauthfile);
+				}
+				addargs(&args, "list");
+				addargs(&args, "%s", display);
+				pid = client_x11_run_xauth_for_windows(cmd, &args, &f);
+				if (pid != 0 && f != NULL &&
+				    fgets(line, sizeof(line), f) &&
+				    sscanf(line, "%*s %511s %511s", proto, data) == 2)
+					got_data = 1;
+				if (f != NULL)
+					fclose(f);
+				if (pid != 0)
+					(void)waitpid(pid, &status, 0);
+				freeargs(&args);
+			}
+#else
 			f = popen(cmd, "r");
 			if (f && fgets(line, sizeof(line), f) &&
 			    sscanf(line, "%*s %511s %511s", proto, data) == 2)
 				got_data = 1;
 			if (f)
 				pclose(f);
+#endif
 			free(cmd);
 		}
 	}

--- a/clientloop.c
+++ b/clientloop.c
@@ -70,7 +70,6 @@
 # include <sys/time.h>
 #endif
 #include <sys/socket.h>
-#include <sys/wait.h>
 
 #include <ctype.h>
 #include <errno.h>
@@ -416,7 +415,6 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 			}
 #ifdef WINDOWS
 			{
-				int status;
 				pid_t pid;
 				arglist args;
 
@@ -433,8 +431,8 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 					addargs(&args, "%u", x11_timeout_real);
 				}
 				pid = client_x11_run_xauth_for_windows(cmd, &args, NULL);
-				if (pid != 0 && waitpid(pid, &status, 0) == pid &&
-				    WIFEXITED(status) && WEXITSTATUS(status) == 0)
+				if (pid != 0 &&
+				    exited_cleanly(pid, "xauth", cmd, 1) == 0)
 					generated = 1;
 				freeargs(&args);
 			}
@@ -464,7 +462,6 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 			debug2("x11_get_proto: %s", cmd);
 #ifdef WINDOWS
 			{
-				int status;
 				pid_t pid;
 				arglist args;
 
@@ -484,7 +481,7 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 				if (f != NULL)
 					fclose(f);
 				if (pid != 0)
-					(void)waitpid(pid, &status, 0);
+					(void)exited_cleanly(pid, "xauth", cmd, 1);
 				freeargs(&args);
 			}
 #else


### PR DESCRIPTION
This fixes PowerShell/Win32-OpenSSH#1803. I'm sure that merging this PR will make the folks very happy, as this issue is very old even though the fix is easy.

I used codex for coding, but I verified and fixed its code.
By compiling (in Windows 11, x64, Release) this codebase both before my change and after, I have reproduced the bug before my change and verified that it fixed after the change.

More testing details - tested on windows terminal (`wt`) under a with the shell of "Command Prompt", connected to this project SSH with the "-Y" flag, and the X11 server I used is VcXsrv. 

### Technical Reasoning

#### Before
xauth was launched via `system`/`popen`, making it accept the process signals from outside (such as sigint, i.e. Ctrl+C), interfearing with the Ctrl+C signal that the user wants to send to the actual running process in the terminal.

#### After
Ensure xauth invocations on Windows use a consistent subprocess path and argument handling instead of `system`/`popen`, avoiding console/signal issues and enabling proper stdout capture and exit-status checks. 

### Description

- Add a helper `client_x11_run_xauth_for_windows` that launches `xauth` via the existing `subprocess` API with consistent flags and optional stdout capture. 
- Replace Windows `system`/`popen` usage in `client_x11_get_proto` with argument-list based calls that use the new helper for both `generate` and `list` code paths and parse captured output.