### PR TITLE
Detect ARM64 host MSBuild in Get-MSBuildPath

### DIFF
--- a/contrib/win32/openssh/OpenSSHBuildHelper.psm1
+++ b/contrib/win32/openssh/OpenSSHBuildHelper.psm1
@@ -647,9 +647,12 @@ function Get-MSBuildPath {
         [string]$VSInstallPath
     )
     $searchPath = "MSBuild\**\Bin\"
-    if($env:PROCESSOR_ARCHITECTURE -ieq "AMD64")
-    {
+    $systemType = (Get-CimInstance Win32_ComputerSystem).SystemType
+    if ($systemType -ieq "x64-based PC") {
         $searchPath += "\amd64"
+    }
+    elseif ($systemType -ieq "ARM64-based PC") {
+        $searchPath += "\arm64"
     }
     $fullSearchPath = Join-Path $VSInstallPath $searchPath
     $toolAvailable = Get-ChildItem -path $fullSearchPath\* -Filter "MSBuild.exe" -ErrorAction SilentlyContinue


### PR DESCRIPTION
# PR Summary

When building on a Windows ARM64 host, Get-MSBuildPath currently resolves to the HostX86 toolchain

```
    31>ClCompile:
         C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\bin\HostX86\arm64\CL.exe
```

instead of the native HostArm64 toolchain.

```
      ClCompile:
         C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\bin\HostArm64\arm64\CL.exe
```

## PR Context