### PR TITLE
Add Match localnetwork / getifaddrs support on Windows

### DIFF
--- a/contrib/win32/openssh/config.h.vs
+++ b/contrib/win32/openssh/config.h.vs
@@ -561,6 +561,12 @@
 /* Define if you have ut_id in utmpx.h */
 /* #undef HAVE_ID_IN_UTMPX */
 
+/* Define to 1 if you have the `getifaddrs' function. */
+#define HAVE_GETIFADDRS 1
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#define HAVE_IFADDRS_H 1
+
 /* Define to 1 if you have the `inet_aton' function. */
 /* #undef HAVE_INET_ATON */
 

--- a/contrib/win32/openssh/ssh.vcxproj
+++ b/contrib/win32/openssh/ssh.vcxproj
@@ -216,7 +216,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 /ignore:4098 /CETCOMPAT %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -242,7 +242,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 /ignore:4098 /CETCOMPAT %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -268,7 +268,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 /ignore:4098 %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -294,7 +294,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 /ignore:4098 %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -322,7 +322,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 /CETCOMPAT %(AdditionalOptions)</AdditionalOptions>
@@ -352,7 +352,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 /CETCOMPAT %(AdditionalOptions)</AdditionalOptions>
@@ -382,7 +382,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 %(AdditionalOptions)</AdditionalOptions>
@@ -412,7 +412,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(ZLibName);Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
       <AdditionalOptions>/debug /debugtype:cv,fixup /opt:ref /opt:icf /incremental:no /ignore:4099 %(AdditionalOptions)</AdditionalOptions>

--- a/contrib/win32/openssh/unittest-win32compat.vcxproj
+++ b/contrib/win32/openssh/unittest-win32compat.vcxproj
@@ -42,6 +42,9 @@
     <ClCompile Include="$(OpenSSH-Src-Path)regress\unittests\win32compat\socket_tests.c">
       <ExcludedFromBuild Condition="$(UseOpenSSL)=='false'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(OpenSSH-Src-Path)regress\unittests\win32compat\getifaddrs_tests.c">
+      <ExcludedFromBuild Condition="$(UseOpenSSL)=='false'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(OpenSSH-Src-Path)regress\unittests\win32compat\tests.c">
       <ExcludedFromBuild Condition="$(UseOpenSSL)=='false'">true</ExcludedFromBuild>
     </ClCompile>
@@ -238,7 +241,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
@@ -264,7 +267,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
@@ -290,7 +293,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
@@ -316,7 +319,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
@@ -344,7 +347,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
@@ -373,7 +376,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
@@ -402,7 +405,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
@@ -431,7 +434,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OpenSSH-Lib-Path)$(Platform)\$(Configuration);$(SolutionDir)\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>posix_compat.lib;libssh.lib;openbsd_compat.lib;Iphlpapi.lib;$(SSLLib)$(AdditionalDependentLibs);%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>wmainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>

--- a/contrib/win32/openssh/win32iocompat.vcxproj
+++ b/contrib/win32/openssh/win32iocompat.vcxproj
@@ -328,6 +328,7 @@
     <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\signal_wait.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\win32_pty.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\gss-sspi.c" />
+    <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\getifaddrs.c" />
     <ClCompile Include="sshTelemetry.c" />
   </ItemGroup>
   <ItemGroup>
@@ -341,6 +342,7 @@
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\sys\wait.h" />
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\unistd.h" />
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\poll.h" />
+    <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\ifaddrs.h" />
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\sys\statvfs.h" />
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\dlfcn.h" />
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\syslog.h" />

--- a/contrib/win32/openssh/win32iocompat.vcxproj.filters
+++ b/contrib/win32/openssh/win32iocompat.vcxproj.filters
@@ -24,6 +24,7 @@
     <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\win32_usertoken_utils.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\gss-sspi.c" />
     <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\win32_pty.c" />
+    <ClCompile Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\getifaddrs.c" />
     <ClCompile Include="sshTelemetry.c" />
   </ItemGroup>
   <ItemGroup>
@@ -50,6 +51,9 @@
       <Filter>inc</Filter>
     </ClInclude>
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\poll.h">
+      <Filter>inc</Filter>
+    </ClInclude>
+    <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\ifaddrs.h">
       <Filter>inc</Filter>
     </ClInclude>
     <ClInclude Include="$(OpenSSH-Src-Path)\contrib\win32\win32compat\inc\sys\wait.h">

--- a/contrib/win32/win32compat/getifaddrs.c
+++ b/contrib/win32/win32compat/getifaddrs.c
@@ -1,0 +1,233 @@
+/*
+ * Author: Steffen Heil <steffen.heil@secforge.de>
+ *
+ * POSIX getifaddrs(3) emulation for Windows.
+ *
+ * Implements getifaddrs()/freeifaddrs() on top of the Win32
+ * GetAdaptersAddresses() API so that the portable OpenSSH code that
+ * enumerates local interface addresses (e.g. the "Match localnetwork"
+ * criterion and "BindInterface") builds and works on Windows.
+ *
+ * Copyright (c) 2026 Steffen Heil
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#include <iphlpapi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "inc\ifaddrs.h"
+
+/* Iphlpapi.lib (GetAdaptersAddresses) is linked via the consuming project. */
+
+/* Recommended initial allocation size from the GetAdaptersAddresses docs. */
+#define WORKING_BUFFER_SIZE 15000
+/* Bound the resize retries should the adapter set keep growing. */
+#define MAX_TRIES 3
+
+/* Duplicate a sockaddr of the given length. */
+static struct sockaddr *
+sockaddr_dup(const struct sockaddr *sa, size_t salen)
+{
+	struct sockaddr *ret;
+
+	if (sa == NULL || salen == 0)
+		return NULL;
+	if ((ret = malloc(salen)) == NULL)
+		return NULL;
+	memcpy(ret, sa, salen);
+	return ret;
+}
+
+/* Build a netmask sockaddr for the given family from a CIDR prefix length. */
+static struct sockaddr *
+prefix_to_netmask(int family, unsigned int prefixlen)
+{
+	if (family == AF_INET) {
+		struct sockaddr_in *sin;
+
+		if ((sin = calloc(1, sizeof(*sin))) == NULL)
+			return NULL;
+		sin->sin_family = AF_INET;
+		if (prefixlen > 32)
+			prefixlen = 32;
+		if (prefixlen != 0)
+			sin->sin_addr.s_addr =
+			    htonl(0xffffffffu << (32 - prefixlen));
+		return (struct sockaddr *)sin;
+	} else if (family == AF_INET6) {
+		struct sockaddr_in6 *sin6;
+		unsigned int i;
+
+		if ((sin6 = calloc(1, sizeof(*sin6))) == NULL)
+			return NULL;
+		sin6->sin6_family = AF_INET6;
+		if (prefixlen > 128)
+			prefixlen = 128;
+		for (i = 0; i < prefixlen; i++)
+			sin6->sin6_addr.s6_addr[i / 8] |=
+			    (unsigned char)(0x80 >> (i % 8));
+		return (struct sockaddr *)sin6;
+	}
+	return NULL;
+}
+
+void
+freeifaddrs(struct ifaddrs *ifa)
+{
+	struct ifaddrs *next;
+
+	while (ifa != NULL) {
+		next = ifa->ifa_next;
+		free(ifa->ifa_name);
+		free(ifa->ifa_addr);
+		free(ifa->ifa_netmask);
+		free(ifa);
+		ifa = next;
+	}
+}
+
+int
+getifaddrs(struct ifaddrs **ifap)
+{
+	IP_ADAPTER_ADDRESSES *adapters = NULL, *aa;
+	IP_ADAPTER_UNICAST_ADDRESS *ua;
+	struct ifaddrs *head = NULL, *cur, **nextp = &head;
+	ULONG size = WORKING_BUFFER_SIZE, ret = 0;
+	int tries = 0;
+	const ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+	    GAA_FLAG_SKIP_DNS_SERVER;
+
+	if (ifap == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	*ifap = NULL;
+
+	/* Retry while the adapter information does not fit the buffer. */
+	do {
+		free(adapters);
+		if ((adapters = malloc(size)) == NULL) {
+			errno = ENOMEM;
+			return -1;
+		}
+		ret = GetAdaptersAddresses(AF_UNSPEC, flags, NULL,
+		    adapters, &size);
+	} while (ret == ERROR_BUFFER_OVERFLOW && ++tries < MAX_TRIES);
+
+	if (ret == ERROR_NO_DATA) {
+		/* No usable addresses present; an empty list is not an error. */
+		free(adapters);
+		return 0;
+	}
+	if (ret != NO_ERROR) {
+		free(adapters);
+		errno = (ret == ERROR_NOT_ENOUGH_MEMORY) ? ENOMEM : ENXIO;
+		return -1;
+	}
+
+	for (aa = adapters; aa != NULL; aa = aa->Next) {
+		char *name = NULL;
+		int namelen = 0;
+
+		/*
+		 * ifa_name is the adapter friendly name (UTF-16 -> UTF-8),
+		 * e.g. "Ethernet" or "Wi-Fi" -- this is what ssh's
+		 * BindInterface matches against on Windows. Fall back to the
+		 * adapter GUID name if the friendly name is unavailable.
+		 */
+		if (aa->FriendlyName != NULL &&
+		    (namelen = WideCharToMultiByte(CP_UTF8, 0, aa->FriendlyName,
+		    -1, NULL, 0, NULL, NULL)) > 0) {
+			if ((name = malloc(namelen)) != NULL &&
+			    WideCharToMultiByte(CP_UTF8, 0, aa->FriendlyName, -1,
+			    name, namelen, NULL, NULL) <= 0) {
+				free(name);
+				name = NULL;
+			}
+		}
+		/* Fall back to the (ANSI) adapter GUID name. */
+		if (name == NULL && aa->AdapterName != NULL)
+			name = _strdup(aa->AdapterName);
+
+		for (ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next) {
+			SOCKET_ADDRESS *sa = &ua->Address;
+			int family;
+
+			if (sa->lpSockaddr == NULL)
+				continue;
+			family = sa->lpSockaddr->sa_family;
+			if (family != AF_INET && family != AF_INET6)
+				continue;
+
+			if ((cur = calloc(1, sizeof(*cur))) == NULL) {
+				free(name);
+				goto nomem;
+			}
+			cur->ifa_addr = sockaddr_dup(sa->lpSockaddr,
+			    sa->iSockaddrLength);
+			if (cur->ifa_addr == NULL) {
+				free(cur);
+				free(name);
+				goto nomem;
+			}
+			/* Best-effort; consumers only require ifa_addr. */
+			cur->ifa_netmask = prefix_to_netmask(family,
+			    ua->OnLinkPrefixLength);
+			if (name != NULL &&
+			    (cur->ifa_name = _strdup(name)) == NULL) {
+				free(cur->ifa_addr);
+				free(cur->ifa_netmask);
+				free(cur);
+				free(name);
+				goto nomem;
+			}
+
+			if (aa->OperStatus == IfOperStatusUp)
+				cur->ifa_flags |= IFF_UP | IFF_RUNNING;
+			if (aa->IfType == IF_TYPE_SOFTWARE_LOOPBACK)
+				cur->ifa_flags |= IFF_LOOPBACK;
+			if ((aa->Flags & IP_ADAPTER_NO_MULTICAST) == 0)
+				cur->ifa_flags |= IFF_MULTICAST;
+
+			*nextp = cur;
+			nextp = &cur->ifa_next;
+		}
+		free(name);
+	}
+
+	free(adapters);
+	*ifap = head;
+	return 0;
+
+ nomem:
+	freeifaddrs(head);
+	free(adapters);
+	errno = ENOMEM;
+	return -1;
+}

--- a/contrib/win32/win32compat/getifaddrs.c
+++ b/contrib/win32/win32compat/getifaddrs.c
@@ -174,6 +174,15 @@ getifaddrs(struct ifaddrs **ifap)
 		/* Fall back to the (ANSI) adapter GUID name. */
 		if (name == NULL && aa->AdapterName != NULL)
 			name = _strdup(aa->AdapterName);
+		/*
+		 * getifaddrs(3) guarantees ifa_name is set, and the consumers
+		 * (readconf.c, sshconnect.c) skip entries with a NULL name --
+		 * never emit one. AdapterName is otherwise always present, so a
+		 * NULL here means allocation failure: fail the call rather than
+		 * silently drop the adapter's addresses.
+		 */
+		if (name == NULL)
+			goto nomem;
 
 		for (ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next) {
 			SOCKET_ADDRESS *sa = &ua->Address;
@@ -199,8 +208,7 @@ getifaddrs(struct ifaddrs **ifap)
 			/* Best-effort; consumers only require ifa_addr. */
 			cur->ifa_netmask = prefix_to_netmask(family,
 			    ua->OnLinkPrefixLength);
-			if (name != NULL &&
-			    (cur->ifa_name = _strdup(name)) == NULL) {
+			if ((cur->ifa_name = _strdup(name)) == NULL) {
 				free(cur->ifa_addr);
 				free(cur->ifa_netmask);
 				free(cur);

--- a/contrib/win32/win32compat/inc/ifaddrs.h
+++ b/contrib/win32/win32compat/inc/ifaddrs.h
@@ -1,0 +1,81 @@
+/*
+ * Author: Steffen Heil <steffen.heil@secforge.de>
+ *
+ * POSIX getifaddrs(3) interface for Windows.
+ *
+ * Declares struct ifaddrs and the getifaddrs()/freeifaddrs() functions that
+ * are implemented in win32compat\getifaddrs.c on top of the Win32
+ * GetAdaptersAddresses() API. This allows the portable OpenSSH code that
+ * enumerates local interface addresses (e.g. the "Match localnetwork"
+ * criterion and "BindInterface") to build and work on Windows.
+ *
+ * Copyright (c) 2026 Steffen Heil
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "sys\socket.h"		/* struct sockaddr */
+
+/*
+ * Interface flags. Windows has no <net/if.h> equivalent, so define the
+ * subset that the portable code inspects (only IFF_UP is currently used).
+ */
+#ifndef IFF_UP
+#define IFF_UP		0x1	/* interface is up */
+#endif
+#ifndef IFF_BROADCAST
+#define IFF_BROADCAST	0x2	/* broadcast address valid */
+#endif
+#ifndef IFF_LOOPBACK
+#define IFF_LOOPBACK	0x8	/* is a loopback net */
+#endif
+#ifndef IFF_POINTOPOINT
+#define IFF_POINTOPOINT	0x10	/* interface is point-to-point link */
+#endif
+#ifndef IFF_RUNNING
+#define IFF_RUNNING	0x40	/* resources allocated */
+#endif
+#ifndef IFF_MULTICAST
+#define IFF_MULTICAST	0x1000	/* supports multicast */
+#endif
+
+struct ifaddrs {
+	struct ifaddrs  *ifa_next;	/* next item in the list */
+	char            *ifa_name;	/* name of the interface */
+	unsigned int     ifa_flags;	/* flags from SIOCGIFFLAGS (IFF_*) */
+	struct sockaddr *ifa_addr;	/* interface address */
+	struct sockaddr *ifa_netmask;	/* interface netmask */
+	union {
+		struct sockaddr *ifu_broadaddr;	/* broadcast address */
+		struct sockaddr *ifu_dstaddr;	/* point-to-point dest addr */
+	} ifa_ifu;
+	void            *ifa_data;	/* address-family specific data */
+};
+
+#define ifa_broadaddr	ifa_ifu.ifu_broadaddr
+#define ifa_dstaddr	ifa_ifu.ifu_dstaddr
+
+int getifaddrs(struct ifaddrs **ifap);
+void freeifaddrs(struct ifaddrs *ifa);

--- a/regress/unittests/win32compat/getifaddrs_tests.c
+++ b/regress/unittests/win32compat/getifaddrs_tests.c
@@ -1,0 +1,51 @@
+/*
+ * Author: Steffen Heil <steffen.heil@secforge.de>
+ *
+ * Tests for the Win32 getifaddrs()/freeifaddrs() implementation
+ * (contrib/win32/win32compat/getifaddrs.c).
+ */
+
+#include "includes.h"
+#include <sys/socket.h>
+#include <ifaddrs.h>
+
+#include "../test_helper/test_helper.h"
+#include "tests.h"
+
+void
+getifaddrs_tests()
+{
+	struct ifaddrs *ifap = NULL, *ifa;
+	int r, count = 0, loopback_up = 0;
+
+	TEST_START("getifaddrs returns a populated list");
+	r = getifaddrs(&ifap);
+	ASSERT_INT_EQ(r, 0);
+	ASSERT_PTR_NE(ifap, NULL);
+	TEST_DONE();
+
+	TEST_START("getifaddrs entries are well-formed");
+	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
+		count++;
+		ASSERT_PTR_NE(ifa->ifa_addr, NULL);
+		ASSERT_PTR_NE(ifa->ifa_name, NULL);
+		/* loopback must be present and marked up (sanity baseline) */
+		if (ifa->ifa_addr->sa_family == AF_INET &&
+		    ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr ==
+		    htonl(INADDR_LOOPBACK) &&
+		    (ifa->ifa_flags & IFF_UP) != 0)
+			loopback_up = 1;
+	}
+	ASSERT_INT_NE(count, 0);
+	TEST_DONE();
+
+	TEST_START("loopback 127.0.0.1 is present and flagged IFF_UP");
+	ASSERT_INT_EQ(loopback_up, 1);
+	TEST_DONE();
+
+	freeifaddrs(ifap);
+
+	TEST_START("freeifaddrs(NULL) is a no-op");
+	freeifaddrs(NULL);
+	TEST_DONE();
+}

--- a/regress/unittests/win32compat/getifaddrs_tests.c
+++ b/regress/unittests/win32compat/getifaddrs_tests.c
@@ -16,31 +16,26 @@ void
 getifaddrs_tests()
 {
 	struct ifaddrs *ifap = NULL, *ifa;
-	int r, count = 0, loopback_up = 0;
+	int r;
 
-	TEST_START("getifaddrs returns a populated list");
+	/*
+	 * getifaddrs() may legitimately return an empty list (no configured
+	 * addresses), so assert only the call result and per-entry invariants
+	 * -- not the presence of any particular interface, which would be
+	 * environment-dependent and flaky.
+	 */
+	TEST_START("getifaddrs succeeds");
 	r = getifaddrs(&ifap);
 	ASSERT_INT_EQ(r, 0);
-	ASSERT_PTR_NE(ifap, NULL);
 	TEST_DONE();
 
 	TEST_START("getifaddrs entries are well-formed");
 	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
-		count++;
+		ASSERT_PTR_NE(ifa->ifa_name, NULL);   /* contract: always set */
 		ASSERT_PTR_NE(ifa->ifa_addr, NULL);
-		ASSERT_PTR_NE(ifa->ifa_name, NULL);
-		/* loopback must be present and marked up (sanity baseline) */
-		if (ifa->ifa_addr->sa_family == AF_INET &&
-		    ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr ==
-		    htonl(INADDR_LOOPBACK) &&
-		    (ifa->ifa_flags & IFF_UP) != 0)
-			loopback_up = 1;
+		ASSERT_INT_EQ(ifa->ifa_addr->sa_family == AF_INET ||
+		    ifa->ifa_addr->sa_family == AF_INET6, 1);
 	}
-	ASSERT_INT_NE(count, 0);
-	TEST_DONE();
-
-	TEST_START("loopback 127.0.0.1 is present and flagged IFF_UP");
-	ASSERT_INT_EQ(loopback_up, 1);
 	TEST_DONE();
 
 	freeifaddrs(ifap);

--- a/regress/unittests/win32compat/tests.c
+++ b/regress/unittests/win32compat/tests.c
@@ -25,6 +25,7 @@ tests()
 	dir_tests();
 	str_tests();
 	miscellaneous_tests();
+	getifaddrs_tests();
 }
 
 char *

--- a/regress/unittests/win32compat/tests.h
+++ b/regress/unittests/win32compat/tests.h
@@ -3,6 +3,7 @@ void signal_tests();
 void socket_tests();
 void file_tests();
 void miscellaneous_tests();
+void getifaddrs_tests();
 
 char *dup_str(char *inStr);
 void delete_dir_recursive(char *full_dir_path);


### PR DESCRIPTION
Tracking issue: PowerShell/Win32-OpenSSH#2440

## Summary

Adds support for the `Match localnetwork` ssh_config criterion on Windows by implementing POSIX `getifaddrs()`/`freeifaddrs()` over the Win32 `GetAdaptersAddresses()` API.

Previously `check_match_ifaddrs()` (`readconf.c`) and the `BindInterface` interface enumeration (`sshconnect.c`) were gated on `HAVE_IFADDRS_H`, which the Windows build never defined, and `win32compat` had no `getifaddrs()` — so `Match localnetwork` always returned *"not supported on this platform"*.

## Changes

- **`contrib/win32/win32compat/inc/ifaddrs.h`** (new): `struct ifaddrs`, `IFF_*` flags (Windows has no `<net/if.h>`), `getifaddrs`/`freeifaddrs` prototypes.
- **`contrib/win32/win32compat/getifaddrs.c`** (new): implementation over `GetAdaptersAddresses()`.
- **`contrib/win32/openssh/config.h.vs`**: define `HAVE_IFADDRS_H` and `HAVE_GETIFADDRS`.
- **`contrib/win32/openssh/win32iocompat.vcxproj` (+ `.filters`)**: build the new sources into `posix_compat.lib`.
- **`contrib/win32/openssh/ssh.vcxproj`**: link `Iphlpapi.lib`.
- **`regress/unittests/win32compat/getifaddrs_tests.c`** (new): unit tests, registered in `tests.c`/`tests.h` and `unittest-win32compat`.

## Notes

- `Match localnetwork` is client-only in 10.0 (`readconf.c` / ssh_config).
- `ifa_name` is the adapter friendly name (what `BindInterface` matches on Windows).
- Disabled/disconnected adapters are returned **without** `IFF_UP`, so the existing consumers skip them (matches POSIX `getifaddrs(3)` semantics).

## Testing

Built on Windows x64 (Release). `ssh.exe` (`OpenSSH_for_Windows_10.0p2`) builds and links; `Match localnetwork 127.0.0.0/8` matches the loopback (enumerated via `getifaddrs`), `203.0.113.0/24` does not, and the "not supported on this platform" path is gone. The `getifaddrs` unit checks pass. Sources also cross-compile for ARM64.
