### PR TITLE
Report failed async connect() through getsockopt(SO_ERROR)

### DIFF
--- a/contrib/win32/win32compat/socketio.c
+++ b/contrib/win32/win32compat/socketio.c
@@ -271,6 +271,29 @@ socketio_setsockopt(struct w32_io* pio, int level, int optname, const char* optv
 int
 socketio_getsockopt(struct w32_io* pio, int level, int optname, char* optval, int* optlen)
 {
+	/*
+	 * A failed asynchronous ConnectEx() reports its error through the
+	 * overlapped completion, which socketio_is_io_available()/
+	 * socketio_finish_connect() capture into write_details.error /
+	 * read_details.error. Once that completion has been consumed the
+	 * underlying socket's SO_ERROR is left at 0, so a plain getsockopt()
+	 * would report success for a connect that actually failed. POSIX code
+	 * relies on getsockopt(SO_ERROR) after a non-blocking connect() to
+	 * detect failure and move on to the next address (e.g. the IPv6 -> IPv4
+	 * fallback loop in ssh_connect_direct()/timeout_connect()). Surface the
+	 * captured error here so that idiom keeps working on Windows.
+	 */
+	if (level == SOL_SOCKET && optname == SO_ERROR && optval != NULL &&
+	    optlen != NULL && *optlen >= (int)sizeof(int)) {
+		DWORD wsa_error = pio->write_details.error ?
+		    pio->write_details.error : pio->read_details.error;
+		if (wsa_error != 0) {
+			*(int*)optval = errno_from_WSAError(wsa_error);
+			*optlen = sizeof(int);
+			return 0;
+		}
+	}
+
 	SET_ERRNO_ON_ERROR(getsockopt(pio->sock, level, optname, optval, optlen));
 }
 

--- a/regress/unittests/win32compat/socket_tests.c
+++ b/regress/unittests/win32compat/socket_tests.c
@@ -700,6 +700,62 @@ socket_typical_ssh_payload_tests() {
 	freeaddrinfo(servinfo);
 }
 
+/*
+ * Regression test: getsockopt(SO_ERROR) must report a failed non-blocking
+ * connect(). A failed asynchronous ConnectEx() stores its error in the
+ * w32_io details but leaves the raw socket SO_ERROR at 0; if getsockopt()
+ * does not surface it, ssh_connect_direct()'s connect loop mistakes the
+ * failed connect for success and never tries the next address (the
+ * IPv6 -> IPv4 fallback that lets dual-stack hosts connect). See
+ * socketio_getsockopt() in contrib/win32/win32compat/socketio.c.
+ */
+void
+socket_connect_error_tests()
+{
+	int so_error, optlen;
+
+	{
+		TEST_START("getsockopt SO_ERROR reports refused connect");
+
+		/* A loopback port with nothing listening -> connect is refused. */
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_socktype = SOCK_STREAM;
+		retValue = getaddrinfo("127.0.0.1", "34999", &hints, &servinfo);
+		ASSERT_INT_EQ(retValue, 0);
+		connect_fd = socket(servinfo->ai_family, servinfo->ai_socktype, servinfo->ai_protocol);
+		ASSERT_INT_NE(connect_fd, -1);
+		ASSERT_INT_EQ(w32_set_nonblock(connect_fd), 0);
+
+		retValue = connect(connect_fd, servinfo->ai_addr, servinfo->ai_addrlen);
+		if (retValue == -1 && errno == EINPROGRESS) {
+			/* wait for the async connect to complete (with an error) */
+			FD_ZERO(&read_set);
+			FD_ZERO(&write_set);
+			FD_SET(connect_fd, &read_set);
+			FD_SET(connect_fd, &write_set);
+			time_val.tv_sec = 5;
+			time_val.tv_usec = 0;
+			retValue = select(connect_fd + 1, &read_set, &write_set, NULL, &time_val);
+			ASSERT_INT_NE(retValue, -1);
+		}
+
+		/*
+		 * The connect was refused, so SO_ERROR must be non-zero. Before the
+		 * fix this returned 0 because the ConnectEx error was not surfaced,
+		 * causing callers to treat the failed connect as a success.
+		 */
+		so_error = 0;
+		optlen = sizeof(so_error);
+		retValue = getsockopt(connect_fd, SOL_SOCKET, SO_ERROR, (char*)&so_error, &optlen);
+		ASSERT_INT_EQ(retValue, 0);
+		ASSERT_INT_NE(so_error, 0);
+
+		close(connect_fd);
+		freeaddrinfo(servinfo);
+		TEST_DONE();
+	}
+}
+
 void
 socket_tests()
 {
@@ -708,4 +764,5 @@ socket_tests()
 	socket_nonblocking_io_tests();
 	socket_select_tests();
 	socket_typical_ssh_payload_tests();
+	socket_connect_error_tests();
 }


### PR DESCRIPTION
Tracking issue: PowerShell/Win32-OpenSSH#2441

## Summary

A failed asynchronous `connect()` is not reported through `getsockopt(SO_ERROR)` on Windows, so `ssh` treats a refused connect as a success and stops at the first resolved address instead of trying the rest (e.g. the IPv6 → IPv4 fallback in `ssh_connect_direct()`). On a dual-stack host whose service answers only on IPv4, `ssh` ends with:

```
banner exchange: Connection to UNKNOWN port -1: Connection refused
```

while the identical invocation falls back to IPv4 and connects on POSIX.

## Cause

`ssh_connect_direct()` (`sshconnect.c`) → `timeout_connect()` (`misc.c`) uses the POSIX idiom: non-blocking `connect()` → `poll(POLLOUT)` → `getsockopt(SO_ERROR)`, where a non-zero `SO_ERROR` means "this address failed, try the next one".

On Windows the asynchronous `ConnectEx()` failure is delivered through the overlapped completion and captured by `socketio_finish_connect()` / `socketio_is_io_available()` into `w32_io.write_details.error` / `read_details.error`; the underlying socket's `SO_ERROR` is left at 0. `socketio_getsockopt()` forwarded `SO_ERROR` straight to the Winsock `getsockopt()` (→ 0), so `timeout_connect()` saw `optval == 0`, reported success, and the address loop never advanced. `getpeername()` on the unconnected socket then yields `UNKNOWN` / `-1`, and the first banner write returns the original `WSAECONNREFUSED`. The same `getsockopt(SO_ERROR)` idiom in `channels.c` (forwarded-channel connects) was affected identically.

## Changes

- **`contrib/win32/win32compat/socketio.c`**: in `socketio_getsockopt()`, for `SOL_SOCKET` / `SO_ERROR` return the captured async-connect error (`write_details.error` / `read_details.error`, mapped via `errno_from_WSAError()`) when one is set, instead of the raw Winsock `SO_ERROR`. Otherwise it falls through to the normal `getsockopt()`.
- **`regress/unittests/win32compat/socket_tests.c`**: regression test (`socket_connect_error_tests`) — a non-blocking `connect()` to a closed loopback port must report a non-zero `SO_ERROR`.

## Testing

Built on Windows x64 (Release). End-to-end: `ssh` to a dual-stack host whose IPv6 endpoint refuses the port now logs `connect to address … Connection refused` and falls back to the IPv4 address (matching POSIX), instead of failing at the banner exchange with `Connection to UNKNOWN port -1`. Added the `socket_connect_error_tests` regression test covering the refused-connect → `getsockopt(SO_ERROR)` path.
