### PR TITLE
FixUserFilePermissions.ps1: use wildcard to get keys

### DIFF
--- a/contrib/win32/openssh/FixUserFilePermissions.ps1
+++ b/contrib/win32/openssh/FixUserFilePermissions.ps1
@@ -10,7 +10,7 @@ if(Test-Path ~\.ssh\config -PathType Leaf)
     Repair-UserSshConfigPermission -FilePath ~\.ssh\config @psBoundParameters
 }
 
-Get-ChildItem ~\.ssh\* -Include "id_rsa","id_dsa","id_ecdsa","id_ed25519" -ErrorAction SilentlyContinue | ForEach-Object {
+Get-ChildItem ~\.ssh\* -Include "id_rsa*","id_dsa*","id_ecdsa*","id_ed25519*" -ErrorAction SilentlyContinue | ForEach-Object {
     Repair-UserKeyPermission -FilePath $_.FullName @psBoundParameters
 }
 

--- a/contrib/win32/openssh/FixUserFilePermissions.ps1
+++ b/contrib/win32/openssh/FixUserFilePermissions.ps1
@@ -10,9 +10,11 @@ if(Test-Path ~\.ssh\config -PathType Leaf)
     Repair-UserSshConfigPermission -FilePath ~\.ssh\config @psBoundParameters
 }
 
-Get-ChildItem ~\.ssh\* -Include "id_rsa*","id_dsa*","id_ecdsa*","id_ed25519*" -ErrorAction SilentlyContinue | ForEach-Object {
-    Repair-UserKeyPermission -FilePath $_.FullName @psBoundParameters
-}
+Get-ChildItem ~\.ssh\* -File -Include "id_rsa*","id_dsa*","id_ecdsa*","id_ed25519*" -ErrorAction SilentlyContinue |
+    Where-Object Extension -eq '' |
+    ForEach-Object {
+        Repair-UserKeyPermission -FilePath $_.FullName @psBoundParameters
+    }
 
 
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use wildcard pattern for `-Include`

## PR Context

ssh keys can have arbitrary names, using algorithm name as prefix should be a common and good practice.
Currently it only matches on exact name, use wildcard to include those with prefixes.