### PR TITLE
Update to use the v0.4 version of `MCPServerPS`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -74,8 +74,11 @@ first-class tools (`mcp_openssh-server_Start_OpenSSHBuild`,
 ### 1. Install the MCP host module
 
 The server is hosted by the `MCPServerPS` PowerShell module, which wraps
-each `.ps1` in `-ScriptRoot` as an MCP tool. See the linked package page
-for installation details: https://github.com/daxian-dbw/MCPServerPS/pkgs/nuget/MCPServerPS
+each `.ps1` in `-ScriptRoot` as an MCP tool.
+To install the module, run the following command:
+```pwsh
+Install-PSResource -Name MCPServerPS -Repository PSGallery
+```
 
 ### 2. Configure VS Code
 
@@ -92,7 +95,7 @@ the repository root — no editing required in that case:
             "args": [
                 "-noprofile",
                 "-c",
-                "MCPServerPS\\Start-MyMCP -ScriptRoot ./.github/tools"
+                "MCPServerPS\\Start-MyMCP -Name openssh-server -ScriptRoot ./.github/tools"
             ],
             "env": {
                 "GITHUB_TOKEN": "${input:github_token}"

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -6,7 +6,7 @@
             "args": [
                 "-noprofile",
                 "-c",
-                "MCPServerPS\\Start-MyMCP -ScriptRoot ./.github/tools"
+                "MCPServerPS\\Start-MyMCP -Name openssh-server -ScriptRoot ./.github/tools"
             ],
             "env": {
                 "GITHUB_TOKEN": "${input:github_token}"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update to use the v0.4 version of `MCPServerPS`.

The MCP view in GitHub Copilot has changed to use `serverInfo.name` returned from the server instead of the server key defined in `mcp.json`. This caused the server name to be inconsistent for MCP servers backed by `MCPServerPS` -- the server key defined in `mcp.json` is meaningful and distinguishable, but GitHub Copilot will simply use the name `pwsh`, `pwsh-1`, `pwsh-2`, etc. because `MCPServerPS` doesn't set the server name explicitly. With v0.4, we are able to explicitly set the server name to be the same as the server key defined in `mcp.json`.

**NOTE: This change requires you to install and use the v0.4 of `MCPServerPS` module.**. Install it by:
```pwsh
Install-PSResource -Name MCPServerPS -Repository PSGallery -Force
```

